### PR TITLE
Support pausing in worker loop

### DIFF
--- a/js/engine.js
+++ b/js/engine.js
@@ -108,6 +108,9 @@ export async function runGreedyLoop(imageData, pins, options, onProgress){
   const maxSteps = options.maxSteps|0;
   const steps = []; let lastProgress = 0;
   for(let k=0;k<maxSteps;k++){
+    if(options.shouldCancel && options.shouldCancel()) break;
+    if(options.waitWhilePaused) await options.waitWhilePaused();
+    if(options.shouldCancel && options.shouldCancel()) break;
     const st = engine.step(); if(!st) break;
     steps.push(st);
     const p = (k+1)/maxSteps;

--- a/js/ui.js
+++ b/js/ui.js
@@ -119,6 +119,15 @@ function bindGenerate(){
         renderPinsAndStrings(rc, data.size, data.pins, data.steps, p.params);
         document.getElementById('e4-step').max=data.steps.length-1;
         document.getElementById('e4-count').textContent=(data.steps.length-1)+' steps';
+      } else if(type==='status'){
+        if(data.state==='paused'){
+          stat.textContent='Paused';
+        } else if(data.state==='running'){
+          stat.textContent='Running';
+        } else if(data.state==='canceled'){
+          bar.style.width='0%';
+          stat.textContent='Canceled';
+        }
       }
     };
     return worker;

--- a/js/workers/compute.worker.js
+++ b/js/workers/compute.worker.js
@@ -1,14 +1,92 @@
 import { runGreedyLoop } from '../engine.js';
-let paused=false, canceled=false;
-self.onmessage = async (e)=>{
-  const {type, data} = e.data;
-  if(type==='run'){
-    paused=false; canceled=false;
-    const opts = { size:data.size, fade:data.fade, minDist:data.minDist, maxSteps:data.maxSteps, progressThrottle:0.02 };
-    const onProgress=(step,score)=>{ if(paused||canceled) return; self.postMessage({type:'progress', data:{step, max:opts.maxSteps, score, progress: step/opts.maxSteps}}); };
-    const res = await runGreedyLoop(new Uint8ClampedArray(data.raster), data.pins, opts, onProgress);
-    if(!canceled) self.postMessage({type:'result', data:{ steps:[0, ...res.steps.map(s=>s.to)], residual:res.residual, durationMs:res.durationMs, pins:res.pins, size:res.size }});
-  }else if(type==='pause'){ paused = true; }
-  else if(type==='resume'){ paused = false; }
-  else if(type==='cancel'){ canceled = true; }
+
+let paused = false, canceled = false;
+const pauseResolvers = [];
+
+const flushResolvers = () => {
+  while (pauseResolvers.length) {
+    const resolve = pauseResolvers.pop();
+    try { resolve(); } catch (err) { console.error(err); }
+  }
+};
+
+const waitWhilePaused = async () => {
+  while (paused && !canceled) {
+    await new Promise((resolve) => pauseResolvers.push(resolve));
+  }
+};
+
+const reportStatus = (state) => {
+  self.postMessage({ type: 'status', data: { state } });
+};
+
+self.onmessage = async (e) => {
+  const { type, data } = e.data;
+  if (type === 'run') {
+    paused = false; canceled = false; flushResolvers();
+    reportStatus('running');
+    const opts = {
+      size: data.size,
+      fade: data.fade,
+      minDist: data.minDist,
+      maxSteps: data.maxSteps,
+      progressThrottle: 0.02,
+      waitWhilePaused,
+      shouldCancel: () => canceled,
+    };
+    const onProgress = (step, score, stepsSnapshot) => {
+      if (paused || canceled) return;
+      self.postMessage({
+        type: 'progress',
+        data: {
+          step,
+          max: opts.maxSteps,
+          score,
+          progress: step / opts.maxSteps,
+          steps: stepsSnapshot,
+          size: opts.size,
+        },
+      });
+    };
+    try {
+      const res = await runGreedyLoop(
+        new Uint8ClampedArray(data.raster),
+        data.pins,
+        opts,
+        onProgress
+      );
+      if (!canceled) {
+        self.postMessage({
+          type: 'result',
+          data: {
+            steps: [0, ...res.steps.map((s) => s.to)],
+            residual: res.residual,
+            durationMs: res.durationMs,
+            pins: res.pins,
+            size: res.size,
+          },
+        });
+      }
+    } finally {
+      flushResolvers();
+    }
+  } else if (type === 'pause') {
+    if (!paused) {
+      paused = true;
+      reportStatus('paused');
+    }
+  } else if (type === 'resume') {
+    if (paused) {
+      paused = false;
+      flushResolvers();
+      reportStatus('running');
+    }
+  } else if (type === 'cancel') {
+    if (!canceled) {
+      canceled = true;
+      paused = false;
+      flushResolvers();
+      reportStatus('canceled');
+    }
+  }
 };


### PR DESCRIPTION
## Summary
- add pause-aware control flow to the compute worker with resumable wait logic and status notifications
- extend runGreedyLoop to honour pause and cancel callbacks before each greedy iteration
- surface worker pause, resume, and cancel states in the generator UI status text

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd4fd7fad8832dacc955d72e1d34d9