### PR TITLE
Send preview data in worker progress updates

### DIFF
--- a/js/engine.js
+++ b/js/engine.js
@@ -111,7 +111,10 @@ export async function runGreedyLoop(imageData, pins, options, onProgress){
     const st = engine.step(); if(!st) break;
     steps.push(st);
     const p = (k+1)/maxSteps;
-    if(onProgress && p - lastProgress >= (options.progressThrottle||0.02)){ lastProgress = p; onProgress(k+1, st.score, engine.steps.slice()); }
+    if(onProgress && p - lastProgress >= (options.progressThrottle||0.02)){
+      lastProgress = p;
+      onProgress(k+1, st.score, engine.steps.slice(), engine.pins);
+    }
   }
   const t1 = performance.now();
   return { steps, residual: engine.residualSum(), durationMs: Math.round(t1-t0), pins: engine.pins, size: engine.size };

--- a/js/ui.js
+++ b/js/ui.js
@@ -100,6 +100,8 @@ function bindGenerate(){
   const rc=document.getElementById('render-canvas');
 
   let worker=null;
+  const previewState = { pins:null, size:null, lastCount:0 };
+  function resetPreviewState(){ previewState.pins=null; previewState.size=null; previewState.lastCount=0; }
   function ensureWorker(){
     if(worker) return worker;
     worker = new Worker('./js/workers/compute.worker.js', {type:'module'});
@@ -109,8 +111,16 @@ function bindGenerate(){
         bar.style.width=(100*data.progress).toFixed(1)+'%';
         stat.textContent='Step ' + data.step + '/' + data.max;
         const p=State.get().project;
-        if(data.steps && data.steps.length>1){
-          renderPinsAndStrings(rc, data.size||p.size, data.pins||buildPins(p.size||data.size, p.params.pins), data.steps, p.params);
+        if(data.pins) previewState.pins = data.pins;
+        if(data.size) previewState.size = data.size;
+        if(p && data.steps && data.steps.length>1 && data.steps.length>previewState.lastCount){
+          const size = previewState.size || p.size;
+          let pins = previewState.pins;
+          if(!pins && size){ pins = buildPins(size, p.params.pins); if(pins) previewState.pins = pins; }
+          if(size && pins){
+            renderPinsAndStrings(rc, size, pins, data.steps, p.params);
+            previewState.lastCount = data.steps.length;
+          }
         }
       } else if(type==='result'){
         const p=State.get().project;
@@ -126,6 +136,7 @@ function bindGenerate(){
 
   btnStart.addEventListener('click', async ()=>{
     const p=State.get().project;
+    resetPreviewState();
     p.params.pins=+document.getElementById('p-pins').value;
     p.params.strings=+document.getElementById('p-steps').value;
     p.params.minDist=+document.getElementById('p-mindist').value;

--- a/js/workers/compute.worker.js
+++ b/js/workers/compute.worker.js
@@ -4,8 +4,29 @@ self.onmessage = async (e)=>{
   const {type, data} = e.data;
   if(type==='run'){
     paused=false; canceled=false;
-    const opts = { size:data.size, fade:data.fade, minDist:data.minDist, maxSteps:data.maxSteps, progressThrottle:0.02 };
-    const onProgress=(step,score)=>{ if(paused||canceled) return; self.postMessage({type:'progress', data:{step, max:opts.maxSteps, score, progress: step/opts.maxSteps}}); };
+    const opts = {
+      size: data.size,
+      fade: data.fade,
+      minDist: data.minDist,
+      maxSteps: Math.max(1, data.maxSteps|0),
+      progressThrottle: 0.02
+    };
+    const previewStepStride = Math.max(1, Math.round(opts.maxSteps * Math.max(opts.progressThrottle*2, 0.04)));
+    let lastPreviewStep = 0;
+    let sentPins = false;
+    const onProgress = (step, score, steps, pins)=>{
+      if(paused||canceled) return;
+      const payload = { step, max: opts.maxSteps, score, progress: step/opts.maxSteps };
+      const hasPreviewSteps = Array.isArray(steps) && steps.length;
+      const shouldSendPreview = hasPreviewSteps && (lastPreviewStep===0 || step - lastPreviewStep >= previewStepStride);
+      if(shouldSendPreview){
+        payload.steps = steps;
+        payload.size = opts.size;
+        lastPreviewStep = step;
+        if(!sentPins && pins){ payload.pins = pins; sentPins = true; }
+      }
+      self.postMessage({type:'progress', data: payload});
+    };
     const res = await runGreedyLoop(new Uint8ClampedArray(data.raster), data.pins, opts, onProgress);
     if(!canceled) self.postMessage({type:'result', data:{ steps:[0, ...res.steps.map(s=>s.to)], residual:res.residual, durationMs:res.durationMs, pins:res.pins, size:res.size }});
   }else if(type==='pause'){ paused = true; }


### PR DESCRIPTION
## Summary
- include preview step snapshots and pin coordinates in compute worker progress messages while throttling heavy updates
- propagate the preview data to the UI renderer and reset preview state between runs
- expose engine pin coordinates through the progress callback

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd4fd1fb58832d8ec9210fce021e4d