### PR TITLE
Add yielding to greedy loop for worker responsiveness

### DIFF
--- a/js/engine.js
+++ b/js/engine.js
@@ -107,6 +107,7 @@ export async function runGreedyLoop(imageData, pins, options, onProgress){
   const engine = new EngineCore({ size: options.size, fade: options.fade, minDist: options.minDist, pins, raster: imageData });
   const maxSteps = options.maxSteps|0;
   const steps = []; let lastProgress = 0;
+  const yieldStride = options.yieldStride|0;
   for(let k=0;k<maxSteps;k++){
     if(options.shouldCancel && options.shouldCancel()) break;
     if(options.waitWhilePaused) await options.waitWhilePaused();
@@ -117,6 +118,9 @@ export async function runGreedyLoop(imageData, pins, options, onProgress){
     if(onProgress && p - lastProgress >= (options.progressThrottle||0.02)){
       lastProgress = p;
       onProgress(k+1, st.score, engine.steps.slice(), engine.pins);
+    }
+    if(options.yieldToQueue && yieldStride>0 && ((k+1)%yieldStride)===0){
+      await options.yieldToQueue();
     }
   }
   const t1 = performance.now();

--- a/js/workers/compute.worker.js
+++ b/js/workers/compute.worker.js
@@ -3,6 +3,8 @@ import { runGreedyLoop } from '../engine.js';
 
 let paused = false, canceled = false;
 const pauseResolvers = [];
+const yieldToQueue = () => new Promise((resolve) => setTimeout(resolve, 0));
+const YIELD_STRIDE = 512;
 
 const flushResolvers = () => {
   while (pauseResolvers.length) {
@@ -36,6 +38,8 @@ self.onmessage = async (e) => {
       progressThrottle: 0.02,
       waitWhilePaused,
       shouldCancel: () => canceled,
+      yieldToQueue,
+      yieldStride: YIELD_STRIDE,
     };
 
     // Önizleme gönderim aralığı (adım sayısına ve throttle'a göre)


### PR DESCRIPTION
## Summary
- allow `runGreedyLoop` to periodically await an async yield callback so the worker can process pending messages
- provide a zero-timeout yield helper in the compute worker and pass it with a stride to the greedy loop options

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cd7effbd34832d805b15992581251e