### PR TITLE
Adjust yield stride based on max steps

### DIFF
--- a/js/engine.js
+++ b/js/engine.js
@@ -107,7 +107,7 @@ export async function runGreedyLoop(imageData, pins, options, onProgress){
   const engine = new EngineCore({ size: options.size, fade: options.fade, minDist: options.minDist, pins, raster: imageData });
   const maxSteps = options.maxSteps|0;
   const steps = []; let lastProgress = 0;
-  const yieldStride = options.yieldStride|0;
+  const yieldStride = Math.max(1, options.yieldStride|0);
   for(let k=0;k<maxSteps;k++){
     if(options.shouldCancel && options.shouldCancel()) break;
     if(options.waitWhilePaused) await options.waitWhilePaused();

--- a/js/workers/compute.worker.js
+++ b/js/workers/compute.worker.js
@@ -4,7 +4,7 @@ import { runGreedyLoop } from '../engine.js';
 let paused = false, canceled = false;
 const pauseResolvers = [];
 const yieldToQueue = () => new Promise((resolve) => setTimeout(resolve, 0));
-const YIELD_STRIDE = 512;
+const MAX_YIELD_STRIDE = 512;
 
 const flushResolvers = () => {
   while (pauseResolvers.length) {
@@ -39,8 +39,12 @@ self.onmessage = async (e) => {
       waitWhilePaused,
       shouldCancel: () => canceled,
       yieldToQueue,
-      yieldStride: YIELD_STRIDE,
     };
+
+    opts.yieldStride = Math.min(
+      MAX_YIELD_STRIDE,
+      Math.max(1, Math.floor(opts.maxSteps / 32))
+    );
 
     // Önizleme gönderim aralığı (adım sayısına ve throttle'a göre)
     const previewStepStride = Math.max(


### PR DESCRIPTION
## Summary
- derive a worker yield stride from the requested max step count and clamp it to a safe range
- ensure the engine loop always uses a positive yield stride when yielding to the queue

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce4726cee4832d931279a25ee591fd