### PR TITLE
Unify board radius handling and refresh crop overlay

### DIFF
--- a/js/engine.js
+++ b/js/engine.js
@@ -1,5 +1,6 @@
+import { BOARD_MARGIN } from './utils.js';
+
 export function initEngine(config){ return new EngineCore(config); }
-const BOARD_MARGIN = 16;
 export class EngineCore{
   constructor(cfg){
     this.size = cfg.size|0;

--- a/js/renderer.js
+++ b/js/renderer.js
@@ -1,15 +1,16 @@
-import { setCanvasSize, hexToRGBA } from './utils.js';
+import { setCanvasSize, hexToRGBA, BOARD_MARGIN } from './utils.js';
 export function renderPinsAndStrings(canvas, size, pins, steps, opts){
   const css = Math.min(canvas.parentElement.clientWidth||size, size);
   const ctx = setCanvasSize(canvas, css);
   ctx.clearRect(0,0,canvas.width,canvas.height);
-  const s = canvas.clientWidth, cx = s/2, cy = s/2, rOuter = (s/2) - 8;
-  ctx.fillStyle = opts.board==='black' ? '#000' : '#fff';
-  ctx.beginPath(); ctx.arc(cx,cy, rOuter, 0, Math.PI*2); ctx.fill();
-  ctx.lineWidth = 10; ctx.strokeStyle = opts.board==='black' ? '#cfd6e6' : '#222';
-  ctx.beginPath(); ctx.arc(cx,cy, rOuter-1, 0, Math.PI*2); ctx.stroke();
-  ctx.fillStyle = '#e9e9e9';
+  const s = canvas.clientWidth, cx = s/2, cy = s/2;
   const scale = s/size;
+  const boardRadius = Math.max(0, (size/2 - BOARD_MARGIN) * scale);
+  ctx.fillStyle = opts.board==='black' ? '#000' : '#fff';
+  ctx.beginPath(); ctx.arc(cx,cy, boardRadius, 0, Math.PI*2); ctx.fill();
+  ctx.lineWidth = 10; ctx.strokeStyle = opts.board==='black' ? '#cfd6e6' : '#222';
+  ctx.beginPath(); ctx.arc(cx,cy, Math.max(0, boardRadius - Math.max(1, scale)), 0, Math.PI*2); ctx.stroke();
+  ctx.fillStyle = '#e9e9e9';
   for(const p of pins){ ctx.beginPath(); ctx.arc(p.x*scale, p.y*scale, (opts.pinSize||4)*scale, 0, Math.PI*2); ctx.fill(); }
   if(!steps || steps.length<2) return;
   ctx.save();
@@ -25,7 +26,7 @@ export function exportSVG(size, pins, steps, opts){
   const stroke = opts.color||'#000000', width = opts.widthPx||0.8;
   const svg = `<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 ${size} ${size}">
-<defs><clipPath id="c"><circle cx="${size/2}" cy="${size/2}" r="${(size/2)-8}"/></clipPath></defs>
+<defs><clipPath id="c"><circle cx="${size/2}" cy="${size/2}" r="${(size/2)-BOARD_MARGIN}"/></clipPath></defs>
 <g clip-path="url(#c)" stroke="${stroke}" stroke-width="${width}" stroke-linecap="round" stroke-linejoin="round">
 ${lines.join('\n')}
 </g>

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,8 +1,6 @@
 import * as State from './state.js';
-import { setCanvasSize } from './utils.js';
+import { setCanvasSize, BOARD_MARGIN } from './utils.js';
 import { renderPinsAndStrings, exportSVG, exportCSV } from './renderer.js';
-
-const BOARD_MARGIN = 16;
 
 let crop = { img:null, scale:1, tx:0, ty:0, rot:0, down:false, lx:0, ly:0, displaySize:0 };
 
@@ -165,23 +163,50 @@ function drawCrop(){
   ctx.clearRect(0,0,cvs.width,cvs.height);
   ctx.restore();
 
-  ctx.fillStyle='#fff';
+  if(crop.img){
+    ctx.save();
+    ctx.beginPath();
+    ctx.arc(cx,cy,radius,0,Math.PI*2);
+    ctx.clip();
+    ctx.fillStyle = '#fff';
+    ctx.fillRect(cx-radius, cy-radius, radius*2, radius*2);
+    ctx.translate(cx + crop.tx, cy + crop.ty);
+    ctx.rotate(crop.rot||0);
+    const sw=crop.img.width, sh=crop.img.height;
+    const minSide=Math.min(sw,sh);
+    const scale=crop.scale*(previewMinSide/minSide);
+    ctx.drawImage(crop.img, -sw*scale/2, -sh*scale/2, sw*scale, sh*scale);
+    ctx.restore();
+  } else {
+    ctx.save();
+    ctx.fillStyle='#fff';
+    ctx.beginPath();
+    ctx.arc(cx,cy,radius,0,Math.PI*2);
+    ctx.fill();
+    ctx.restore();
+  }
+
+  const overlayW = displayW || (cvs.width / dpr);
+  const overlayH = displayH || (cvs.height / dpr);
+  ctx.save();
+  ctx.fillStyle = 'rgba(0,0,0,0.45)';
+  ctx.fillRect(0,0,overlayW,overlayH);
+  ctx.globalCompositeOperation = 'destination-out';
   ctx.beginPath();
   ctx.arc(cx,cy,radius,0,Math.PI*2);
   ctx.fill();
-  if(!crop.img) return;
-
-  ctx.save();
-  ctx.beginPath();
-  ctx.arc(cx,cy,radius,0,Math.PI*2);
-  ctx.clip();
-  ctx.translate(cx + crop.tx, cy + crop.ty);
-  ctx.rotate(crop.rot||0);
-  const sw=crop.img.width, sh=crop.img.height;
-  const minSide=Math.min(sw,sh);
-  const scale=crop.scale*(previewMinSide/minSide);
-  ctx.drawImage(crop.img, -sw*scale/2, -sh*scale/2, sw*scale, sh*scale);
   ctx.restore();
+
+  if(radius>0){
+    ctx.save();
+    ctx.setLineDash([8,6]);
+    ctx.lineWidth = 2;
+    ctx.strokeStyle = 'rgba(255,255,255,0.9)';
+    ctx.beginPath();
+    ctx.arc(cx,cy,radius,0,Math.PI*2);
+    ctx.stroke();
+    ctx.restore();
+  }
 }
 
 function bindGenerate(){

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,4 +1,6 @@
-export const DPR = Math.min(2, Math.max(1, window.devicePixelRatio || 1));
+const devicePixelRatio = (typeof window !== 'undefined' && window.devicePixelRatio) ? window.devicePixelRatio : 1;
+export const DPR = Math.min(2, Math.max(1, devicePixelRatio));
+export const BOARD_MARGIN = 16;
 export function setCanvasSize(canvas, cssSize){
   const dpr = DPR;
   canvas.style.width = cssSize + 'px';


### PR DESCRIPTION
## Summary
- export a shared BOARD_MARGIN constant alongside a worker-safe DPR fallback
- update the crop canvas to draw with the shared board radius, including overlay and dashed ring, and persist circle metadata
- align pin generation, rendering, and SVG export to the shared radius so previews stay in sync

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ce6c56dbe4832d9195727428357efc