### PR TITLE
Prevent touch gestures from scrolling crop canvas

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -19,6 +19,7 @@ button.good{background:color-mix(in srgb, #22c55e 22%, #0f1320 78%);border-color
 input,select{width:100%;padding:10px 12px;border-radius:8px;border:1px solid var(--ring);background:#0f1320;color:var(--text)}
 .canvas-wrap{display:flex;justify-content:center;align-items:center;min-height:50vh}
 canvas{display:block;width:100%;height:auto;border-radius:12px;background:#111}
+#crop-canvas{touch-action:none}
 .list{list-style:none;margin:0;padding:0;display:grid;gap:8px}
 .list li{display:flex;justify-content:space-between;gap:8px;align-items:center;background:#0f1320;border:1px solid var(--ring);padding:8px 10px;border-radius:10px}
 .meter{height:10px;border-radius:999px;background:#0d1220;border:1px solid var(--ring);overflow:hidden;margin-top:8px}

--- a/js/ui.js
+++ b/js/ui.js
@@ -104,8 +104,22 @@ function bindCrop(){
   zoom.addEventListener('input', ()=>{ crop.scale=+zoom.value; drawCrop(); });
   rot.addEventListener('input', ()=>{ crop.rot = +rot.value * Math.PI/180; drawCrop(); });
 
-  cvs.addEventListener('pointerdown', e=>{ crop.down=true; crop.lx=e.clientX; crop.ly=e.clientY; cvs.setPointerCapture(e.pointerId); });
-  cvs.addEventListener('pointermove', e=>{ if(!crop.down) return; crop.tx+=(e.clientX-crop.lx); crop.ty+=(e.clientY-crop.ly); crop.lx=e.clientX; crop.ly=e.clientY; drawCrop(); });
+  cvs.addEventListener('pointerdown', e=>{
+    crop.down=true;
+    crop.lx=e.clientX;
+    crop.ly=e.clientY;
+    cvs.setPointerCapture(e.pointerId);
+    e.preventDefault();
+  });
+  cvs.addEventListener('pointermove', e=>{
+    if(!crop.down) return;
+    e.preventDefault();
+    crop.tx+=(e.clientX-crop.lx);
+    crop.ty+=(e.clientY-crop.ly);
+    crop.lx=e.clientX;
+    crop.ly=e.clientY;
+    drawCrop();
+  });
   cvs.addEventListener('pointerup', ()=>{ crop.down=false; });
 
   document.getElementById('crop-confirm').addEventListener('click', async()=>{


### PR DESCRIPTION
## Summary
- prevent default touch behavior during crop pointer interactions so drags stay within the canvas
- disable touch scrolling on the crop canvas via CSS touch-action

## Testing
- not run (touch interaction requires device/emulator)


------
https://chatgpt.com/codex/tasks/task_e_68ce7b5c0d30832d89780812d645c2ba