### PR TITLE
Refactor navigation into bottom tab bar

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -2,10 +2,9 @@
 *{box-sizing:border-box}
 html,body{height:100%}
 body{margin:0;background:var(--bg);color:var(--text);font:14px/1.5 system-ui,Segoe UI,Roboto,Arial}
-.app-header{position:sticky;top:0;z-index:5;display:flex;gap:12px;align-items:center;justify-content:space-between;padding:10px 14px;border-bottom:1px solid var(--ring);backdrop-filter:blur(8px)}
+.app-header{position:sticky;top:0;z-index:5;display:flex;align-items:center;justify-content:center;padding:18px 16px;border-bottom:1px solid var(--ring);backdrop-filter:blur(8px);text-align:center}
 .app-header h1{margin:0;font-size:16px;color:var(--brand)}
-.app-header nav button{background:#0f1320;border:1px solid var(--ring);color:var(--text);padding:8px 10px;border-radius:10px;cursor:pointer}
-.screen{display:none;padding:14px;max-width:980px;margin:0 auto}
+.screen{display:none;padding:14px;max-width:980px;margin:0 auto;padding-bottom:120px}
 .screen.active{display:block}
 .panel{background:var(--panel);border:1px solid var(--ring);border-radius:12px;padding:12px;margin-bottom:12px;box-shadow:0 6px 24px rgba(0,0,0,.25)}
 .row{display:grid;grid-template-columns:1fr 1fr;gap:10px}
@@ -26,3 +25,17 @@ canvas{display:block;width:100%;height:auto;border-radius:12px;background:#111}
 .meter>i{display:block;height:100%;width:0%;background:linear-gradient(90deg,var(--brand),var(--accent))}
 .hint{color:var(--muted);font-size:12px}
 .tiny{color:var(--muted);font-size:12px}
+
+.app-nav{position:fixed;bottom:0;left:0;right:0;z-index:10;display:flex;gap:8px;justify-content:space-around;padding:10px 12px calc(10px + env(safe-area-inset-bottom,0));background-color:color-mix(in srgb, var(--panel) 92%, transparent);backdrop-filter:blur(12px);border-top:1px solid var(--ring)}
+.app-nav button{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:6px;padding:10px 12px;border-radius:14px;background:color-mix(in srgb, #101522 92%, transparent);border:1px solid transparent;color:var(--muted);font-size:11px;text-transform:uppercase;letter-spacing:0.05em;font-weight:600;transition:color .2s ease, background-color .2s ease, border-color .2s ease}
+.app-nav button svg{width:24px;height:24px}
+.app-nav button svg path{fill:none;stroke:currentColor;stroke-width:1.8;stroke-linecap:round;stroke-linejoin:round}
+.app-nav button svg circle{fill:currentColor}
+.app-nav button.is-active{color:var(--text);background:color-mix(in srgb, var(--brand) 20%, #101522 80%);border-color:color-mix(in srgb, var(--brand) 35%, transparent)}
+.app-nav button:focus-visible{outline:2px solid var(--brand);outline-offset:2px}
+.app-nav button:hover{color:var(--text)}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+
+@supports(padding:max(0px)){
+  .app-nav{padding:10px 12px max(10px, env(safe-area-inset-bottom,0));}
+}

--- a/index.html
+++ b/index.html
@@ -10,12 +10,6 @@
 <body>
 <header class="app-header">
   <h1>Hammer Design · String Art</h1>
-  <nav>
-    <button data-nav="1" aria-controls="screen-1">Home</button>
-    <button data-nav="2" aria-controls="screen-2">Crop</button>
-    <button data-nav="3" aria-controls="screen-3">Generate</button>
-    <button data-nav="4" aria-controls="screen-4">Steps</button>
-  </nav>
 </header>
 
 <main id="app">
@@ -102,6 +96,37 @@
     </div>
   </section>
 </main>
+
+<nav class="app-nav" aria-label="Primary">
+  <button type="button" data-nav="1" aria-controls="screen-1">
+    <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+      <path d="M3 10.5 12 3l9 7.5v10.5a1 1 0 0 1-1 1h-5v-6h-6v6H4a1 1 0 0 1-1-1z"/>
+    </svg>
+    <span class="sr-only">Home</span>
+  </button>
+  <button type="button" data-nav="2" aria-controls="screen-2">
+    <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+      <path d="M7 5H5v4M5 15v4h4M17 5h4v4M17 19h4v-4"/>
+      <path d="M9 9h6v6H9z"/>
+    </svg>
+    <span class="sr-only">Crop</span>
+  </button>
+  <button type="button" data-nav="3" aria-controls="screen-3">
+    <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+      <path d="M12 4v4m0 8v4m8-8h-4m-8 0H4m13.07-7.07-2.83 2.83m0 6.48 2.83 2.83M6.93 6.93l2.83 2.83m0 6.48-2.83 2.83"/>
+    </svg>
+    <span class="sr-only">Generate</span>
+  </button>
+  <button type="button" data-nav="4" aria-controls="screen-4">
+    <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+      <path d="M9 7h10M9 12h10M9 17h10"/>
+      <circle cx="5" cy="7" r="1.5"/>
+      <circle cx="5" cy="12" r="1.5"/>
+      <circle cx="5" cy="17" r="1.5"/>
+    </svg>
+    <span class="sr-only">Steps</span>
+  </button>
+</nav>
 
 <script type="module">
   import * as State from './js/state.js';

--- a/js/state.js
+++ b/js/state.js
@@ -1,12 +1,15 @@
 import { idbPutBlob, idbGetBlob } from './utils.js';
 const LS_KEY = 'sa.projects.v1';
 const state = { screen: 1, project: null };
+const navigateListeners = new Set();
 export function go(n){
   state.screen = n;
   document.querySelectorAll('.screen').forEach(s=>s.classList.remove('active'));
   const el = document.getElementById(`screen-${n}`);
   if(el) el.classList.add('active');
+  navigateListeners.forEach(fn=>{ try{ fn(n); }catch(err){ console.error(err); } });
 }
+export function onNavigate(fn){ if(typeof fn==='function') navigateListeners.add(fn); return ()=>navigateListeners.delete(fn); }
 export function newProjectFromImage(file){
   const id = 'p_' + Date.now().toString(36);
   const proj = { id, name: file.name || 'Untitled', createdAt: Date.now(), updatedAt: Date.now(),

--- a/js/ui.js
+++ b/js/ui.js
@@ -3,13 +3,32 @@ import { setCanvasSize, BOARD_MARGIN } from './utils.js';
 import { renderPinsAndStrings, exportSVG, exportCSV } from './renderer.js';
 
 const EXPORT_SIZE = 1440;
+let navButtons = [];
+let removeNavigateListener = null;
 
 let crop = { img:null, scale:1, tx:0, ty:0, rot:0, down:false, lx:0, ly:0, displaySize:0 };
 
 export function mount(){
-  document.querySelectorAll('header nav [data-nav]').forEach(b=>{ b.addEventListener('click', ()=>State.go(+b.dataset.nav)); });
+  navButtons = Array.from(document.querySelectorAll('.app-nav [data-nav]'));
+  navButtons.forEach(b=>{ b.addEventListener('click', ()=>State.go(+b.dataset.nav)); });
+  setActiveNav(State.get().screen);
+  if(removeNavigateListener) removeNavigateListener();
+  removeNavigateListener = State.onNavigate(setActiveNav);
   const file = document.getElementById('e1-file'); file.addEventListener('change', onPickImage);
   refreshProjectList(); bindCrop(); bindGenerate(); bindViewer();
+}
+
+function setActiveNav(screenId){
+  const target = Number(screenId);
+  navButtons.forEach(btn=>{
+    const isActive = Number(btn.dataset.nav) === target;
+    btn.classList.toggle('is-active', isActive);
+    if(isActive){
+      btn.setAttribute('aria-current','page');
+    } else {
+      btn.removeAttribute('aria-current');
+    }
+  });
 }
 
 function refreshProjectList(){


### PR DESCRIPTION
## Summary
- move the primary navigation into a fixed bottom tab bar with inline SVG icons and sr-only labels
- add styles for the bottom navigation, adjust header spacing, and pad screens so content clears the new bar
- notify UI of route changes through a new `State.onNavigate` helper so the active tab and aria attributes stay in sync

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d15a9ef588832dbc54aec70ec4693e