### PR TITLE
Refactor step viewer layout and controls

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -26,3 +26,19 @@ canvas{display:block;width:100%;height:auto;border-radius:12px;background:#111}
 .meter>i{display:block;height:100%;width:0%;background:linear-gradient(90deg,var(--brand),var(--accent))}
 .hint{color:var(--muted);font-size:12px}
 .tiny{color:var(--muted);font-size:12px}
+.e4-board-wrap{position:relative;display:flex;flex-direction:column;gap:12px;align-items:center}
+.e4-export-row{display:flex;flex-wrap:wrap;gap:8px;align-self:flex-start}
+.e4-board-wrap .canvas-wrap{width:100%}
+.e4-progress{margin-top:12px;display:grid;grid-template-columns:auto minmax(0,1fr) auto;gap:12px;align-items:center}
+.e4-progress-center{display:flex;flex-direction:column;gap:6px;text-align:center}
+.e4-progress-bar{position:relative;height:10px;border-radius:999px;background:#0d1220;border:1px solid var(--ring);overflow:hidden}
+#e4-progress-fill{display:block;height:100%;width:0;background:linear-gradient(90deg,var(--brand),var(--accent))}
+.e4-progress button{white-space:nowrap}
+.e4-progress-actions{display:flex;gap:8px;flex-wrap:wrap;justify-content:flex-end}
+.e4-step-cells{margin-top:12px;display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:10px}
+.e4-step-cell{display:flex;flex-direction:column;justify-content:center;align-items:center;background:#0f1320;border:1px solid var(--ring);border-radius:10px;padding:12px;min-height:60px;font-size:18px;font-weight:600}
+.e4-step-cell [data-value][hidden],.e4-step-cell [data-placeholder][hidden]{display:none}
+.e4-step-cell [data-placeholder]{color:var(--muted);font-weight:400}
+.e4-controls{margin-top:12px;display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:12px}
+.e4-control-group{display:flex;gap:8px;flex-wrap:wrap;justify-content:center}
+.e4-control-speed,.e4-control-voice{white-space:nowrap}

--- a/index.html
+++ b/index.html
@@ -87,16 +87,53 @@
 
   <section id="screen-4" class="screen" role="region" aria-label="Steps">
     <div class="panel">
-      <div class="row">
-        <label>Step <input id="e4-step" type="range" min="0" max="0" step="1" value="0"/></label>
-        <span id="e4-count" class="tiny"></span>
+      <div class="e4-board-wrap">
+        <div class="e4-export-row">
+          <button id="exp-png" class="good">Export PNG</button>
+          <button id="exp-svg">Export SVG</button>
+          <button id="exp-csv">Export CSV</button>
+          <button id="exp-json">Export JSON</button>
+        </div>
+        <div class="canvas-wrap"><canvas id="viewer-canvas" width="1440" height="1440" aria-label="Viewer"></canvas></div>
       </div>
-      <div class="canvas-wrap"><canvas id="viewer-canvas" width="1440" height="1440" aria-label="Viewer"></canvas></div>
-      <div class="btns">
-        <button id="exp-png" class="good">Export PNG</button>
-        <button id="exp-svg">Export SVG</button>
-        <button id="exp-csv">Export CSV</button>
-        <button id="exp-json">Export JSON</button>
+
+      <div class="e4-progress">
+        <button id="e4-first">First</button>
+        <div class="e4-progress-center">
+          <span id="e4-progress-label">0 / 0</span>
+          <div class="e4-progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="0" aria-valuenow="0">
+            <i id="e4-progress-fill"></i>
+          </div>
+        </div>
+        <div class="e4-progress-actions">
+          <button id="e4-last">Last</button>
+          <button id="e4-step-jump">Adıma git</button>
+        </div>
+      </div>
+
+      <div class="e4-step-cells">
+        <div id="e4-prev-pin" class="e4-step-cell">
+          <span class="e4-step-value" data-value></span>
+          <span class="e4-step-placeholder" data-placeholder>—</span>
+        </div>
+        <div id="e4-current-pin" class="e4-step-cell">
+          <span class="e4-step-value" data-value></span>
+          <span class="e4-step-placeholder" data-placeholder>—</span>
+        </div>
+        <div id="e4-next-pin" class="e4-step-cell">
+          <span class="e4-step-value" data-value></span>
+          <span class="e4-step-placeholder" data-placeholder>—</span>
+        </div>
+      </div>
+
+      <div class="e4-controls">
+        <button id="e4-speed" class="e4-control-speed">Speed 3s</button>
+        <div class="e4-control-group">
+          <button id="e4-prev">Prev</button>
+          <button id="e4-play" aria-pressed="false">Play</button>
+          <button id="e4-next">Next</button>
+        </div>
+        <button id="e4-voice" class="e4-control-voice" aria-pressed="false">Voice Off</button>
       </div>
       <div class="tiny">© 2025 Hammer Design</div>
     </div>


### PR DESCRIPTION
## Summary
- redesign the Steps panel to group the board, export actions, progress toolbar, and transport controls
- add styling for the new board wrapper, progress indicator, step cells, and control layout
- replace the slider-driven viewer logic with stateful controls, progress updates, and playback helpers

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d174cfbe54832d9ec2c12a95c79a8f