### PR TITLE
Refine screen 4 board layout and controls

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -41,19 +41,42 @@ canvas{display:block;width:100%;height:auto;border-radius:12px;background:#111}
 }
 
 /* e4 ekranı */
-.e4-board-wrap{position:relative;display:flex;flex-direction:column;gap:12px;align-items:center}
-.e4-export-row{display:flex;flex-wrap:wrap;gap:8px;align-self:flex-start}
-.e4-board-wrap .canvas-wrap{width:100%}
-.e4-progress{margin-top:12px;display:grid;grid-template-columns:auto minmax(0,1fr) auto;gap:12px;align-items:center}
-.e4-progress-center{display:flex;flex-direction:column;gap:6px;text-align:center}
-.e4-progress-bar{position:relative;height:10px;border-radius:999px;background:#0d1220;border:1px solid var(--ring);overflow:hidden}
-#e4-progress-fill{display:block;height:100%;width:0;background:linear-gradient(90deg,var(--brand),var(--accent))}
-.e4-progress button{white-space:nowrap}
-.e4-progress-actions{display:flex;gap:8px;flex-wrap:wrap;justify-content:flex-end}
-.e4-step-cells{margin-top:12px;display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:10px}
-.e4-step-cell{display:flex;flex-direction:column;justify-content:center;align-items:center;background:#0f1320;border:1px solid var(--ring);border-radius:10px;padding:12px;min-height:60px;font-size:18px;font-weight:600}
-.e4-step-cell [data-value][hidden],.e4-step-cell [data-placeholder][hidden]{display:none}
-.e4-step-cell [data-placeholder]{color:var(--muted);font-weight:400}
-.e4-controls{margin-top:12px;display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:12px}
-.e4-control-group{display:flex;gap:8px;flex-wrap:wrap;justify-content:center}
-.e4-control-speed,.e4-control-voice{white-space:nowrap}
+#screen-4 .panel{display:flex;flex-direction:column;gap:20px}
+#screen-4 .e4-board-wrap{position:relative;display:flex;flex-direction:column;gap:16px;align-items:center;width:100%}
+#screen-4 .e4-board-wrap .canvas-wrap{width:100%}
+#screen-4 .e4-toolbar{display:flex;flex-wrap:wrap;gap:10px;justify-content:flex-start;align-self:flex-start}
+#screen-4 .e4-toolbar button{flex:0 0 auto}
+#screen-4 .e4-progress{display:grid;grid-template-columns:auto minmax(0,1fr) auto;gap:16px;align-items:center}
+#screen-4 .e4-progress button{white-space:nowrap}
+#screen-4 .e4-progress-center{display:flex;flex-direction:column;gap:6px;text-align:center}
+#screen-4 #e4-progress-label{font-size:18px;font-weight:700;letter-spacing:.03em}
+#screen-4 .e4-progress-bar{position:relative;height:12px;border-radius:999px;background:color-mix(in srgb, #0f1320 70%, transparent);border:1px solid color-mix(in srgb, var(--brand) 30%, var(--ring) 70%);overflow:hidden;box-shadow:inset 0 0 0 1px rgba(4,9,20,.35)}
+#screen-4 .e4-progress-fill{display:block;height:100%;width:0;background:linear-gradient(90deg,var(--brand),color-mix(in srgb, var(--accent) 65%, var(--brand) 35%));transition:width .25s ease}
+#screen-4 .e4-progress-actions{display:flex;gap:10px;flex-wrap:wrap;justify-content:flex-end}
+#screen-4 .e4-step-cells{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:12px}
+#screen-4 .e4-cell{display:flex;flex-direction:column;justify-content:center;align-items:center;gap:6px;text-align:center;padding:16px;border-radius:14px;background:color-mix(in srgb, #0f1320 90%, transparent);border:1px solid color-mix(in srgb, var(--ring) 85%, transparent);min-height:88px;font-size:20px;font-weight:600;transition:border-color .2s ease,background-color .2s ease,color .2s ease,box-shadow .2s ease}
+#screen-4 .e4-cell .e4-step-value{font-size:28px;letter-spacing:.02em}
+#screen-4 .e4-cell .e4-step-placeholder{color:var(--muted);font-weight:500;letter-spacing:.08em;text-transform:uppercase}
+#screen-4 .e4-cell.is-active{border-color:color-mix(in srgb, var(--brand) 60%, transparent);background:color-mix(in srgb, var(--brand) 18%, #0f1320 82%);box-shadow:0 0 0 1px color-mix(in srgb, var(--brand) 55%, transparent)}
+#screen-4 .e4-cell.is-active .e4-step-placeholder{opacity:.5}
+#screen-4 .e4-cell.is-empty{background:color-mix(in srgb, #0f1320 60%, transparent);border-style:dashed;color:var(--muted)}
+#screen-4 .e4-cell.is-disabled{opacity:.55;filter:saturate(.6)}
+#screen-4 .e4-cell [data-value][hidden],#screen-4 .e4-cell [data-placeholder][hidden]{display:none}
+#screen-4 .e4-controls{display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap}
+#screen-4 .e4-controls>button{flex:0 0 auto}
+#screen-4 .e4-speed,#screen-4 .e4-voice{white-space:nowrap}
+#screen-4 .e4-transport{display:flex;align-items:center;justify-content:center;gap:10px;flex-wrap:wrap}
+#screen-4 .e4-transport button{min-width:88px}
+#screen-4 .e4-speed.is-on{border-color:color-mix(in srgb, var(--accent) 55%, transparent);background:color-mix(in srgb, var(--accent) 24%, #0f1320 76%);box-shadow:0 0 0 1px color-mix(in srgb, var(--accent) 40%, transparent)}
+#screen-4 .e4-voice.is-on{border-color:color-mix(in srgb, var(--brand) 55%, transparent);background:color-mix(in srgb, var(--brand) 22%, #0f1320 78%);box-shadow:0 0 0 1px color-mix(in srgb, var(--brand) 35%, transparent)}
+
+@media(max-width:720px){
+  #screen-4 .e4-progress{grid-template-columns:1fr;gap:12px}
+  #screen-4 .e4-progress-actions{justify-content:center}
+  #screen-4 .e4-progress button{width:100%}
+  #screen-4 .e4-progress-center{text-align:center}
+  #screen-4 .e4-controls{justify-content:center}
+  #screen-4 .e4-controls>button{flex:1 1 160px}
+  #screen-4 .e4-transport{width:100%}
+  #screen-4 .e4-transport button{flex:1 1 100px}
+}

--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
   <section id="screen-4" class="screen" role="region" aria-label="Steps">
     <div class="panel">
       <div class="e4-board-wrap">
-        <div class="e4-export-row">
+        <div class="e4-toolbar">
           <button id="exp-png" class="good">Export PNG</button>
           <button id="exp-svg">Export SVG</button>
           <button id="exp-csv">Export CSV</button>
@@ -96,7 +96,7 @@
         <div class="e4-progress-center">
           <span id="e4-progress-label">0 / 0</span>
           <div class="e4-progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="0" aria-valuenow="0">
-            <i id="e4-progress-fill"></i>
+            <i id="e4-progress-fill" class="e4-progress-fill"></i>
           </div>
         </div>
         <div class="e4-progress-actions">
@@ -106,28 +106,28 @@
       </div>
 
       <div class="e4-step-cells">
-        <div id="e4-prev-pin" class="e4-step-cell">
+        <div id="e4-prev-pin" class="e4-step-cell e4-cell">
           <span class="e4-step-value" data-value></span>
           <span class="e4-step-placeholder" data-placeholder>—</span>
         </div>
-        <div id="e4-current-pin" class="e4-step-cell">
+        <div id="e4-current-pin" class="e4-step-cell e4-cell">
           <span class="e4-step-value" data-value></span>
           <span class="e4-step-placeholder" data-placeholder>—</span>
         </div>
-        <div id="e4-next-pin" class="e4-step-cell">
+        <div id="e4-next-pin" class="e4-step-cell e4-cell">
           <span class="e4-step-value" data-value></span>
           <span class="e4-step-placeholder" data-placeholder>—</span>
         </div>
       </div>
 
       <div class="e4-controls">
-        <button id="e4-speed" class="e4-control-speed">Speed 3s</button>
-        <div class="e4-control-group">
+        <button id="e4-speed" class="e4-control-speed e4-speed">Speed 3s</button>
+        <div class="e4-control-group e4-transport">
           <button id="e4-prev">Prev</button>
           <button id="e4-play" aria-pressed="false">Play</button>
           <button id="e4-next">Next</button>
         </div>
-        <button id="e4-voice" class="e4-control-voice" aria-pressed="false">Voice Off</button>
+        <button id="e4-voice" class="e4-control-voice e4-voice" aria-pressed="false">Voice Off</button>
       </div>
       <div class="tiny">© 2025 Hammer Design</div>
     </div>


### PR DESCRIPTION
## Summary
- scope the screen 4 layout styles under `#screen-4` and introduce new toolbar, progress, step cell, and control classes
- center the board, left-align the export toolbar, and restyle the progress indicator and step cells with active/empty state variants
- ensure the control row wraps on narrow viewports and add visual feedback for toggled speed and voice buttons

## Testing
- not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d185006bd8832dafdcc133a2ce425a