### PR TITLE
Remove header banner

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -2,8 +2,6 @@
 *{box-sizing:border-box}
 html,body{height:100%}
 body{margin:0;background:var(--bg);color:var(--text);font:14px/1.5 system-ui,Segoe UI,Roboto,Arial}
-.app-header{position:sticky;top:0;z-index:5;display:flex;align-items:center;justify-content:center;padding:18px 16px;border-bottom:1px solid var(--ring);backdrop-filter:blur(8px);text-align:center}
-.app-header h1{margin:0;font-size:16px;color:var(--brand)}
 .screen{display:none;padding:14px;max-width:980px;margin:0 auto;padding-bottom:120px}
 .screen.active{display:block}
 .panel{background:var(--panel);border:1px solid var(--ring);border-radius:12px;padding:12px;margin-bottom:12px;box-shadow:0 6px 24px rgba(0,0,0,.25)}

--- a/index.html
+++ b/index.html
@@ -8,10 +8,6 @@
 <link rel="icon" href="data:,">
 </head>
 <body>
-<header class="app-header">
-  <h1>Hammer Design · String Art</h1>
-</header>
-
 <main id="app">
   <section id="screen-1" class="screen" role="region" aria-label="Home">
     <div class="panel">


### PR DESCRIPTION
## Summary
- remove the sticky header markup from `index.html` so the title banner no longer renders
- delete the related `.app-header` styles to avoid leftover spacing

## Testing
- python3 -m http.server 8000 (manual verification via Playwright while server was running)


------
https://chatgpt.com/codex/tasks/task_e_68d26c206d54832d9189390b826f492a