### PR TITLE
Disable progress bar step navigation

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -48,8 +48,8 @@ canvas{display:block;width:100%;height:auto;border-radius:12px;background:#111}
 #screen-4 .e4-progress button{white-space:nowrap}
 #screen-4 .e4-progress-center{display:flex;flex-direction:column;gap:6px;text-align:center}
 #screen-4 #e4-progress-label{font-size:18px;font-weight:700;letter-spacing:.03em}
-#screen-4 .e4-progress-bar{position:relative;height:12px;border-radius:999px;background:color-mix(in srgb, #0f1320 70%, transparent);border:1px solid color-mix(in srgb, var(--brand) 30%, var(--ring) 70%);overflow:hidden;box-shadow:inset 0 0 0 1px rgba(4,9,20,.35)}
-#screen-4 .e4-progress-fill{display:block;height:100%;width:0;background:linear-gradient(90deg,var(--brand),color-mix(in srgb, var(--accent) 65%, var(--brand) 35%));transition:width .25s ease}
+#screen-4 .e4-progress-bar{position:relative;height:12px;border-radius:999px;background:color-mix(in srgb, #0f1320 70%, transparent);border:1px solid color-mix(in srgb, var(--brand) 30%, var(--ring) 70%);overflow:hidden;box-shadow:inset 0 0 0 1px rgba(4,9,20,.35);cursor:default;pointer-events:none}
+#screen-4 .e4-progress-fill{display:block;height:100%;width:0;background:linear-gradient(90deg,var(--brand),color-mix(in srgb, var(--accent) 65%, var(--brand) 35%));transition:width .25s ease;cursor:default}
 #screen-4 .e4-progress-actions{display:flex;gap:10px;flex-wrap:wrap;justify-content:flex-end}
 #screen-4 .e4-step-cells{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:12px}
 #screen-4 .e4-cell{display:flex;flex-direction:column;justify-content:center;align-items:center;gap:6px;text-align:center;padding:16px;border-radius:14px;background:color-mix(in srgb, #0f1320 90%, transparent);border:1px solid color-mix(in srgb, var(--ring) 85%, transparent);min-height:88px;font-size:20px;font-weight:600;transition:border-color .2s ease,background-color .2s ease,color .2s ease,box-shadow .2s ease}

--- a/js/ui.js
+++ b/js/ui.js
@@ -670,19 +670,6 @@ function bindViewer(){
     });
   }
 
-  if(ui.progressBar){
-    ui.progressBar.addEventListener('pointerdown', e=>{
-      if(viewerState.steps.length===0) return;
-      const rect = ui.progressBar.getBoundingClientRect();
-      const ratio = rect.width>0 ? (e.clientX - rect.left) / rect.width : 0;
-      const clampedRatio = Math.max(0, Math.min(1, ratio));
-      const targetIndex = Math.round(clampedRatio * (viewerState.steps.length - 1));
-      stopAutoPlay();
-      setStep(targetIndex, {announce:true});
-      e.preventDefault();
-    });
-  }
-
   if(ui.voiceButton && !viewerState.isVoiceSupported){
     if(!ui.voiceInfo){
       const info = document.createElement('span');


### PR DESCRIPTION
## Summary
- Remove the `.e4-progress-bar` pointerdown handler so the viewer only advances via the transport controls and step-jump prompt.
- Style the progress bar and fill with a default cursor and no pointer events to emphasize that the bar is presentational.

## Testing
- Manual Playwright scenario verifying the progress bar no longer changes steps while the "Adıma git" prompt still works.


------
https://chatgpt.com/codex/tasks/task_e_68d26d42cc90832da6360daea2550676