### PR TITLE
Adjust progress indicator to zero-based steps

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -350,19 +350,20 @@ function setStep(index, {announce = true} = {}){
 
 function updateProgressIndicators(){
   const { progressLabel, progressFill, progressBar, prevPinCell, currentPinCell, nextPinCell } = viewerState.ui;
-  const total = viewerState.steps.length;
-  const current = total > 0 ? viewerState.stepIndex + 1 : 0;
+  const totalSteps = Math.max(viewerState.steps.length - 1, 0);
+  const currentStep = Math.min(viewerState.stepIndex, totalSteps);
   if(progressLabel){
-    progressLabel.textContent = `Step ${current} / ${total}`;
+    progressLabel.textContent = `Step ${currentStep} / ${totalSteps}`;
   }
   if(progressFill){
-    const pct = total > 0 ? ((viewerState.stepIndex + 1) / total) * 100 : 0;
+    let pct = totalSteps > 0 ? (currentStep / totalSteps) * 100 : 0;
+    pct = Number.isFinite(pct) ? Math.min(Math.max(pct, 0), 100) : 0;
     progressFill.style.width = pct.toFixed(1) + '%';
   }
   if(progressBar){
     progressBar.setAttribute('aria-valuemin', '0');
-    progressBar.setAttribute('aria-valuemax', String(total));
-    progressBar.setAttribute('aria-valuenow', String(current));
+    progressBar.setAttribute('aria-valuemax', String(totalSteps));
+    progressBar.setAttribute('aria-valuenow', String(currentStep));
   }
   updateStepCell(prevPinCell, viewerState.steps[viewerState.stepIndex - 1]);
   updateStepCell(currentPinCell, viewerState.steps[viewerState.stepIndex]);


### PR DESCRIPTION
## Summary
- compute progress totals using zero-based indices so empty states show Step 0 / 0
- clamp the progress bar fill percentage and sync ARIA attributes with zero-based values

## Testing
- node - <<'NODE'
const scenarios = [
  { steps: [], stepIndex: 0, label: 'no steps' },
  { steps: [0, 1, 2], stepIndex: 0, label: 'first step' },
  { steps: [0, 1, 2], stepIndex: 1, label: 'middle step' },
  { steps: [0, 1, 2], stepIndex: 2, label: 'last step' },
  { steps: [0, 1, 2], stepIndex: 5, label: 'beyond last step' },
];

for(const scenario of scenarios){
  const totalSteps = Math.max(scenario.steps.length - 1, 0);
  const currentStep = Math.min(scenario.stepIndex, totalSteps);
  const pctRaw = totalSteps > 0 ? (currentStep / totalSteps) * 100 : 0;
  const pct = Number.isFinite(pctRaw) ? Math.min(Math.max(pctRaw, 0), 100) : 0;
  console.log(scenario.label, { totalSteps, currentStep, pct: pct.toFixed(1) });
}
NODE

------
https://chatgpt.com/codex/tasks/task_e_68d28047ea20832db704dae9605663b4