### PR TITLE
Adjust E4 keypad layout sizing

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -51,12 +51,12 @@ canvas{display:block;width:100%;height:auto;border-radius:12px;background:#111}
 #screen-4 .e4-progress-bar{position:relative;height:12px;border-radius:999px;background:color-mix(in srgb, #0f1320 70%, transparent);border:1px solid color-mix(in srgb, var(--brand) 30%, var(--ring) 70%);overflow:hidden;box-shadow:inset 0 0 0 1px rgba(4,9,20,.35);cursor:default;pointer-events:none}
 #screen-4 .e4-progress-fill{display:block;height:100%;width:0;background:linear-gradient(90deg,var(--brand),color-mix(in srgb, var(--accent) 65%, var(--brand) 35%));transition:width .25s ease;cursor:default}
 #screen-4 .e4-progress-actions{display:flex;gap:10px;flex-wrap:wrap;justify-content:flex-end}
-#screen-4 .e4-step-cells{display:grid;grid-template-columns:repeat(auto-fit,minmax(72px,1fr));gap:8px}
-#screen-4 .e4-cell{display:flex;flex-direction:column;justify-content:center;align-items:center;gap:6px;text-align:center;padding:8px 10px;border-radius:14px;background:color-mix(in srgb, #0f1320 90%, transparent);border:1px solid color-mix(in srgb, var(--ring) 70%, transparent);min-height:44px;font-size:18px;font-weight:600;transition:border-color .2s ease,background-color .2s ease,color .2s ease,box-shadow .2s ease}
-#screen-4 #e4-current-pin{padding:12px 14px;font-size:20px}
-#screen-4 #e4-current-pin .e4-step-value{font-size:30px}
-#screen-4 .e4-cell .e4-step-value{font-size:24px;letter-spacing:.02em}
-#screen-4 .e4-cell .e4-step-placeholder{color:var(--muted);font-weight:500;letter-spacing:.08em;text-transform:uppercase}
+#screen-4 .e4-step-cells{display:grid;grid-template-columns:minmax(48px,max-content) minmax(72px,max-content) minmax(48px,max-content);gap:8px;justify-content:center}
+#screen-4 .e4-cell{display:flex;flex-direction:column;justify-content:center;align-items:center;gap:6px;text-align:center;padding:6px 8px;border-radius:14px;background:color-mix(in srgb, #0f1320 90%, transparent);border:1px solid color-mix(in srgb, var(--ring) 70%, transparent);min-height:38px;font-size:16px;font-weight:600;transition:border-color .2s ease,background-color .2s ease,color .2s ease,box-shadow .2s ease}
+#screen-4 #e4-current-pin{padding:14px 20px;font-size:19px;min-height:48px}
+#screen-4 #e4-current-pin .e4-step-value{font-size:32px}
+#screen-4 .e4-cell .e4-step-value{font-size:22px;letter-spacing:.02em}
+#screen-4 .e4-cell .e4-step-placeholder{color:var(--muted);font-weight:500;letter-spacing:.08em;text-transform:uppercase;font-size:12px}
 #screen-4 .e4-cell.is-active{border-color:color-mix(in srgb, var(--brand) 65%, transparent);background:color-mix(in srgb, var(--brand) 22%, #0f1320 78%);box-shadow:0 0 0 2px color-mix(in srgb, var(--brand) 45%, transparent)}
 #screen-4 .e4-cell.is-active .e4-step-placeholder{opacity:.5}
 #screen-4 .e4-cell.is-empty{background:color-mix(in srgb, #0f1320 70%, transparent);border-style:dashed;border-color:color-mix(in srgb, var(--ring) 55%, transparent);color:var(--muted)}


### PR DESCRIPTION
## Summary
- align the screen 4 keypad grid to three columns with a wider middle slot
- reduce base cell padding and typography for a tighter visual wrap
- emphasize the current pin cell with larger padding and type while keeping state styles consistent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2a36b8f50832d80c1f599c3dbb5c1