### PR TITLE
Add icon-only export buttons

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -13,6 +13,10 @@ button{appearance:none;border:1px solid var(--ring);background:#0f1320;color:var
 button.primary{background:color-mix(in srgb, var(--brand) 22%, #0f1320 78%);border-color:#1e78a8}
 button.danger{background:color-mix(in srgb, #ef4444 22%, #0f1320 78%);border-color:#7a2a2a}
 button.good{background:color-mix(in srgb, #22c55e 22%, #0f1320 78%);border-color:#2e7d60}
+.icon-btn{width:44px;height:44px;padding:0;display:inline-flex;align-items:center;justify-content:center;gap:0;line-height:0;border-radius:12px;transition:transform .18s ease, box-shadow .18s ease}
+.icon-btn svg{width:24px;height:24px;display:block;transition:transform .18s ease}
+.icon-btn:hover svg,.icon-btn:focus-visible svg{transform:translateY(-1px)}
+.icon-btn:focus-visible{outline:2px solid var(--brand);outline-offset:2px}
 input,select{width:100%;padding:10px 12px;border-radius:8px;border:1px solid var(--ring);background:#0f1320;color:var(--text)}
 .canvas-wrap{display:flex;justify-content:center;align-items:center;min-height:50vh}
 canvas{display:block;width:100%;height:auto;border-radius:12px;background:#111}

--- a/index.html
+++ b/index.html
@@ -79,10 +79,58 @@
     <div class="panel">
       <div class="e4-board-wrap">
         <div class="e4-toolbar">
-          <button id="exp-png" class="good">Export PNG</button>
-          <button id="exp-svg">Export SVG</button>
-          <button id="exp-csv">Export CSV</button>
-          <button id="exp-json">Export JSON</button>
+          <button id="exp-png" class="good icon-btn">
+            <svg aria-hidden="true" viewBox="0 0 32 32" focusable="false">
+              <g fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M16 5v11"/>
+                <path d="m12.5 12.5 3.5 3.5 3.5-3.5"/>
+                <path d="M7 17v6a3 3 0 0 0 3 3h12a3 3 0 0 0 3-3v-6"/>
+                <path d="M11 23h10"/>
+              </g>
+              <rect x="5" y="5" width="14" height="9" rx="2.5" fill="currentColor" opacity="0.12" stroke="currentColor" stroke-width="1.5"/>
+              <text x="12" y="9.5" text-anchor="middle" dominant-baseline="middle" font-size="4.4" font-weight="700" font-family="inherit" fill="currentColor">PNG</text>
+            </svg>
+            <span class="sr-only">Export PNG</span>
+          </button>
+          <button id="exp-svg" class="icon-btn">
+            <svg aria-hidden="true" viewBox="0 0 32 32" focusable="false">
+              <g fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M16 5v11"/>
+                <path d="m12.5 12.5 3.5 3.5 3.5-3.5"/>
+                <path d="M7 17v6a3 3 0 0 0 3 3h12a3 3 0 0 0 3-3v-6"/>
+                <path d="M11 23h10"/>
+              </g>
+              <rect x="5" y="5" width="14" height="9" rx="2.5" fill="currentColor" opacity="0.12" stroke="currentColor" stroke-width="1.5"/>
+              <text x="12" y="9.5" text-anchor="middle" dominant-baseline="middle" font-size="4.4" font-weight="700" font-family="inherit" fill="currentColor">SVG</text>
+            </svg>
+            <span class="sr-only">Export SVG</span>
+          </button>
+          <button id="exp-csv" class="icon-btn">
+            <svg aria-hidden="true" viewBox="0 0 32 32" focusable="false">
+              <g fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M16 5v11"/>
+                <path d="m12.5 12.5 3.5 3.5 3.5-3.5"/>
+                <path d="M7 17v6a3 3 0 0 0 3 3h12a3 3 0 0 0 3-3v-6"/>
+                <path d="M11 23h10"/>
+              </g>
+              <rect x="5" y="5" width="14" height="9" rx="2.5" fill="currentColor" opacity="0.12" stroke="currentColor" stroke-width="1.5"/>
+              <text x="12" y="9.5" text-anchor="middle" dominant-baseline="middle" font-size="4.4" font-weight="700" font-family="inherit" fill="currentColor">CSV</text>
+            </svg>
+            <span class="sr-only">Export CSV</span>
+          </button>
+          <button id="exp-json" class="icon-btn">
+            <svg aria-hidden="true" viewBox="0 0 32 32" focusable="false">
+              <g fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M16 5v11"/>
+                <path d="m12.5 12.5 3.5 3.5 3.5-3.5"/>
+                <path d="M7 17v6a3 3 0 0 0 3 3h12a3 3 0 0 0 3-3v-6"/>
+                <path d="M11 23h10"/>
+              </g>
+              <rect x="5" y="5" width="14" height="9" rx="2.5" fill="currentColor" opacity="0.12" stroke="currentColor" stroke-width="1.5"/>
+              <text x="12" y="9.5" text-anchor="middle" dominant-baseline="middle" font-size="3.6" font-weight="700" font-family="inherit" fill="currentColor">JSON</text>
+            </svg>
+            <span class="sr-only">Export JSON</span>
+          </button>
         </div>
         <div class="canvas-wrap"><canvas id="viewer-canvas" width="1440" height="1440" aria-label="Viewer"></canvas></div>
       </div>


### PR DESCRIPTION
## Summary
- replace the export button labels with inline SVG icons while preserving screen reader text
- add a reusable `.icon-btn` style for consistent icon button sizing and focus behavior

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d2c0e27110832da5547fe9c476e020