### PR TITLE
Replace progress transport text with icons

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -48,8 +48,10 @@ canvas{display:block;width:100%;height:auto;border-radius:12px;background:#111}
 #screen-4 .e4-board-wrap .canvas-wrap{width:100%}
 #screen-4 .e4-toolbar{display:flex;flex-wrap:wrap;gap:10px;justify-content:flex-start;align-self:flex-start}
 #screen-4 .e4-toolbar button{flex:0 0 auto}
-#screen-4 .e4-progress{display:grid;grid-template-columns:auto minmax(0,1fr) auto;gap:16px;align-items:center}
+#screen-4 .e4-progress{display:grid;grid-template-columns:auto minmax(0,1fr) auto;gap:14px;align-items:center}
 #screen-4 .e4-progress button{white-space:nowrap}
+#screen-4 .e4-progress .icon-btn{width:42px;height:42px;min-width:42px;padding:0;border-radius:11px;display:inline-flex;align-items:center;justify-content:center}
+#screen-4 .e4-progress .icon-btn svg{width:22px;height:22px}
 #screen-4 .e4-progress-center{display:flex;flex-direction:column;gap:6px;text-align:center}
 #screen-4 #e4-progress-label{font-size:18px;font-weight:700;letter-spacing:.03em}
 #screen-4 .e4-progress-bar{position:relative;height:12px;border-radius:999px;background:color-mix(in srgb, #0f1320 70%, transparent);border:1px solid color-mix(in srgb, var(--brand) 30%, var(--ring) 70%);overflow:hidden;box-shadow:inset 0 0 0 1px rgba(4,9,20,.35);cursor:default;pointer-events:none}

--- a/index.html
+++ b/index.html
@@ -136,7 +136,13 @@
       </div>
 
       <div class="e4-progress">
-        <button id="e4-first">First</button>
+        <button id="e4-first" class="icon-btn">
+          <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+            <path d="M7 5v14" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+            <path d="M17 19 9 12l8-7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+          </svg>
+          <span class="sr-only">First step</span>
+        </button>
         <div class="e4-progress-center">
           <span id="e4-progress-label">0 / 0</span>
           <div class="e4-progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="0" aria-valuenow="0">
@@ -144,8 +150,19 @@
           </div>
         </div>
         <div class="e4-progress-actions">
-          <button id="e4-last">Last</button>
-          <button id="e4-step-jump">Adıma git</button>
+          <button id="e4-last" class="icon-btn">
+            <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+              <path d="M17 5v14" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+              <path d="m7 5 8 7-8 7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+            </svg>
+            <span class="sr-only">Last step</span>
+          </button>
+          <button id="e4-step-jump" class="icon-btn">
+            <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+              <path d="M5 9h14M5 15h14M9 5v14M15 5v14" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+            </svg>
+            <span class="sr-only">Jump to step</span>
+          </button>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- swap the text labels on the progress transport buttons for inline SVG icons with screen reader labels
- ensure the buttons share the icon styling used elsewhere and size them evenly within the progress area

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2c316bd54832dbd962efd6ff82d40