### PR TITLE
Add SVG transport controls for step viewer

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -76,7 +76,9 @@ canvas{display:block;width:100%;height:auto;border-radius:12px;background:#111}
 #screen-4 .e4-speed,#screen-4 .e4-voice{white-space:nowrap}
 #screen-4 .e4-speed.is-open{border-color:color-mix(in srgb, var(--accent) 55%, transparent);background:color-mix(in srgb, var(--accent) 22%, #0f1320 78%);box-shadow:0 0 0 1px color-mix(in srgb, var(--accent) 35%, transparent)}
 #screen-4 .e4-transport{display:flex;align-items:center;justify-content:center;gap:10px;flex-wrap:wrap}
-#screen-4 .e4-transport button{min-width:88px}
+#screen-4 .e4-transport .icon-btn{width:44px;height:44px;min-width:44px;padding:0}
+#screen-4 .e4-transport .icon-btn svg{width:24px;height:24px}
+#screen-4 #e4-play [data-state][hidden],#screen-4 #e4-play .sr-only[data-state][hidden]{display:none}
 #screen-4 .e4-speed.is-on{border-color:color-mix(in srgb, var(--accent) 55%, transparent);background:color-mix(in srgb, var(--accent) 24%, #0f1320 76%);box-shadow:0 0 0 1px color-mix(in srgb, var(--accent) 40%, transparent)}
 #screen-4 .e4-voice.is-on{border-color:color-mix(in srgb, var(--brand) 55%, transparent);background:color-mix(in srgb, var(--brand) 22%, #0f1320 78%);box-shadow:0 0 0 1px color-mix(in srgb, var(--brand) 35%, transparent)}
 
@@ -98,5 +100,5 @@ canvas{display:block;width:100%;height:auto;border-radius:12px;background:#111}
   #screen-4 .e4-controls>.e4-speed-control{flex:1 1 160px}
   .e4-speed-menu{left:0;right:auto;width:100%;max-width:100%}
   #screen-4 .e4-transport{width:100%}
-  #screen-4 .e4-transport button{flex:1 1 100px}
+  #screen-4 .e4-transport .icon-btn{flex:0 0 44px}
 }

--- a/index.html
+++ b/index.html
@@ -187,9 +187,31 @@
           <ul id="e4-speed-menu" class="e4-speed-menu" role="menu" aria-hidden="true"></ul>
         </div>
         <div class="e4-control-group e4-transport">
-          <button id="e4-prev">Prev</button>
-          <button id="e4-play" aria-pressed="false">Play</button>
-          <button id="e4-next">Next</button>
+          <button id="e4-prev" class="icon-btn" type="button">
+            <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+              <path d="m14 6-6 6 6 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            <span class="sr-only">Previous step</span>
+          </button>
+          <button id="e4-play" class="icon-btn" type="button" aria-pressed="false">
+            <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false" data-state="play">
+              <path d="m10 7 8 5-8 5z" fill="currentColor"/>
+            </svg>
+            <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false" data-state="pause" hidden>
+              <g fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+                <path d="M10 7v10"/>
+                <path d="M14 7v10"/>
+              </g>
+            </svg>
+            <span class="sr-only" data-state="play">Play</span>
+            <span class="sr-only" data-state="pause" hidden>Pause</span>
+          </button>
+          <button id="e4-next" class="icon-btn" type="button">
+            <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+              <path d="m10 6 6 6-6 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            <span class="sr-only">Next step</span>
+          </button>
         </div>
         <button id="e4-voice" class="e4-control-voice e4-voice" aria-pressed="false">Voice Off</button>
       </div>

--- a/js/ui.js
+++ b/js/ui.js
@@ -454,8 +454,17 @@ function updateSpeedButton(){
 function updatePlayButton(){
   const { playButton } = viewerState.ui;
   if(!playButton) return;
-  playButton.textContent = viewerState.isAutoPlaying ? 'Pause' : 'Play';
-  playButton.setAttribute('aria-pressed', viewerState.isAutoPlaying ? 'true' : 'false');
+  const isPlaying = viewerState.isAutoPlaying;
+  playButton.setAttribute('aria-pressed', isPlaying ? 'true' : 'false');
+  playButton.setAttribute('aria-label', isPlaying ? 'Pause' : 'Play');
+  const playStateEls = playButton.querySelectorAll('[data-state="play"]');
+  const pauseStateEls = playButton.querySelectorAll('[data-state="pause"]');
+  playStateEls.forEach(el=>{
+    el.hidden = isPlaying;
+  });
+  pauseStateEls.forEach(el=>{
+    el.hidden = !isPlaying;
+  });
 }
 
 function updateVoiceButton(){


### PR DESCRIPTION
## Summary
- replace the string viewer transport buttons with inline SVG icons and add dual-state markup for the play toggle
- size the transport buttons to match other icon buttons and hide inactive play/pause states in CSS
- update the play button logic to toggle SVG visibility and aria attributes without overwriting the button contents

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2c6233528832da7a1be2e6fff913b