### PR TITLE
Refine playback speed button layout

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -74,6 +74,10 @@ canvas{display:block;width:100%;height:auto;border-radius:12px;background:#111}
 #screen-4 .e4-speed-control{position:relative;display:flex;flex-direction:column;align-items:stretch;min-width:0}
 #screen-4 .e4-speed-control .e4-speed{width:100%}
 #screen-4 .e4-speed,#screen-4 .e4-voice{white-space:nowrap}
+#screen-4 .e4-speed{display:inline-flex;align-items:center;justify-content:center;gap:6px;padding:10px 12px}
+#screen-4 .e4-speed .speed-icon{width:18px;height:18px;flex:0 0 auto;display:block}
+#screen-4 .e4-speed .speed-value{display:inline-flex;align-items:center;justify-content:center;font-variant-numeric:tabular-nums;letter-spacing:.01em}
+#screen-4 .e4-speed .speed-caret{font-size:12px;line-height:1;flex:0 0 auto}
 #screen-4 .e4-speed.is-open{border-color:color-mix(in srgb, var(--accent) 55%, transparent);background:color-mix(in srgb, var(--accent) 22%, #0f1320 78%);box-shadow:0 0 0 1px color-mix(in srgb, var(--accent) 35%, transparent)}
 #screen-4 .e4-transport{display:flex;align-items:center;justify-content:center;gap:10px;flex-wrap:wrap}
 #screen-4 .e4-transport .icon-btn{width:44px;height:44px;min-width:44px;padding:0}

--- a/index.html
+++ b/index.html
@@ -183,7 +183,20 @@
 
       <div class="e4-controls">
         <div class="e4-speed-control">
-          <button id="e4-speed" class="e4-control-speed e4-speed" type="button" aria-haspopup="menu" aria-expanded="false">Speed 3s</button>
+          <button id="e4-speed" class="e4-control-speed e4-speed" type="button" aria-haspopup="menu" aria-expanded="false">
+            <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false" class="speed-icon">
+              <g fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="12" cy="13" r="7"/>
+                <path d="M12 9v4l3 1.5"/>
+                <path d="M9 4h6"/>
+                <path d="M10 2h4"/>
+                <path d="m17.5 6.5 1.5-1.5"/>
+              </g>
+            </svg>
+            <span class="speed-value" aria-hidden="true">3s</span>
+            <span class="speed-caret" aria-hidden="true">▾</span>
+            <span class="sr-only">Playback speed</span>
+          </button>
           <ul id="e4-speed-menu" class="e4-speed-menu" role="menu" aria-hidden="true"></ul>
         </div>
         <div class="e4-control-group e4-transport">

--- a/js/ui.js
+++ b/js/ui.js
@@ -447,7 +447,11 @@ function updateSpeedButton(){
   if(!speedButton) return;
   const ms = viewerState.autoPlayDelayMs || AUTO_PLAY_SPEEDS[0];
   const label = formatSpeedLabel(ms);
-  speedButton.textContent = 'Speed ' + label;
+  const valueEl = speedButton.querySelector('.speed-value');
+  if(valueEl){
+    valueEl.textContent = label;
+  }
+  speedButton.setAttribute('aria-label', `Playback speed ${label}`);
   updateSpeedMenuSelection();
 }
 


### PR DESCRIPTION
## Summary
- add stopwatch icon, caret, and accessible spans to the playback speed control markup
- style the playback speed button for compact horizontal alignment of the icon, label, and caret
- update the speed button logic to refresh only the visible speed value while preserving static content

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d2c90ab47c832db9b9853882e4f206