### PR TITLE
Improve voice control button visuals and behaviour

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -82,6 +82,13 @@ canvas{display:block;width:100%;height:auto;border-radius:12px;background:#111}
 #screen-4 .e4-transport{display:flex;align-items:center;justify-content:center;gap:10px;flex-wrap:wrap}
 #screen-4 .e4-transport .icon-btn{width:44px;height:44px;min-width:44px;padding:0}
 #screen-4 .e4-transport .icon-btn svg{width:24px;height:24px}
+#screen-4 .e4-voice{width:44px;height:44px;min-width:44px;padding:0;display:inline-flex;align-items:center;justify-content:center;gap:0;line-height:0;border-radius:12px;transition:transform .18s ease, box-shadow .18s ease}
+#screen-4 .e4-voice:focus-visible{outline:2px solid var(--brand);outline-offset:2px}
+#screen-4 .e4-voice .voice-icon{display:none;align-items:center;justify-content:center}
+#screen-4 .e4-voice .voice-icon.is-active{display:flex}
+#screen-4 .e4-voice .voice-icon[hidden]{display:none}
+#screen-4 .e4-voice .voice-icon svg{width:24px;height:24px;display:block;transition:transform .18s ease}
+#screen-4 .e4-voice:hover .voice-icon.is-active svg,#screen-4 .e4-voice:focus-visible .voice-icon.is-active svg{transform:translateY(-1px)}
 #screen-4 #e4-play [data-state][hidden],#screen-4 #e4-play .sr-only[data-state][hidden]{display:none}
 #screen-4 .e4-speed.is-on{border-color:color-mix(in srgb, var(--accent) 55%, transparent);background:color-mix(in srgb, var(--accent) 24%, #0f1320 76%);box-shadow:0 0 0 1px color-mix(in srgb, var(--accent) 40%, transparent)}
 #screen-4 .e4-voice.is-on{border-color:color-mix(in srgb, var(--brand) 55%, transparent);background:color-mix(in srgb, var(--brand) 22%, #0f1320 78%);box-shadow:0 0 0 1px color-mix(in srgb, var(--brand) 35%, transparent)}

--- a/index.html
+++ b/index.html
@@ -226,7 +226,37 @@
             <span class="sr-only">Next step</span>
           </button>
         </div>
-        <button id="e4-voice" class="e4-control-voice e4-voice" aria-pressed="false">Voice Off</button>
+        <button id="e4-voice" class="e4-control-voice e4-voice" type="button" aria-pressed="false" aria-label="Voice off">
+          <span class="sr-only" data-voice-label>Voice off</span>
+          <span class="voice-icon is-active" data-state="off">
+            <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+              <path d="M12 3a3 3 0 0 1 3 3v6a3 3 0 0 1-6 0V6a3 3 0 0 1 3-3z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M5 11v1a7 7 0 0 0 14 0v-1" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M12 19v4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M8 23h8" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </span>
+          <span class="voice-icon" data-state="on">
+            <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+              <path d="M12 3a3 3 0 0 1 3 3v6a3 3 0 0 1-6 0V6a3 3 0 0 1 3-3z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M5 11v1a7 7 0 0 0 14 0v-1" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M12 19v4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M8 23h8" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M18 8a4 4 0 0 1 0 8" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M20.5 6.5a7 7 0 0 1 0 11" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </span>
+          <span class="voice-icon" data-state="unavailable">
+            <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+              <path d="M12 3a3 3 0 0 1 3 3v6a3 3 0 0 1-6 0V6a3 3 0 0 1 3-3z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M5 11v1a7 7 0 0 0 14 0v-1" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M12 19v4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M8 23h8" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M16 15l4 4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M20 15l-4 4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </span>
+        </button>
       </div>
       <div class="tiny">© 2025 Hammer Design</div>
     </div>

--- a/js/ui.js
+++ b/js/ui.js
@@ -474,11 +474,35 @@ function updatePlayButton(){
 function updateVoiceButton(){
   const { voiceButton, voiceInfo } = viewerState.ui;
   if(!voiceButton) return;
+  const icons = {
+    off: voiceButton.querySelector('[data-state="off"]'),
+    on: voiceButton.querySelector('[data-state="on"]'),
+    unavailable: voiceButton.querySelector('[data-state="unavailable"]')
+  };
+  const labelEl = voiceButton.querySelector('[data-voice-label]');
+  const setActiveState = state => {
+    Object.entries(icons).forEach(([key, icon])=>{
+      if(!icon) return;
+      const isActive = key === state;
+      icon.classList.toggle('is-active', isActive);
+      if(isActive){
+        icon.removeAttribute('hidden');
+      } else {
+        icon.setAttribute('hidden', '');
+      }
+    });
+  };
   if(!viewerState.isVoiceSupported){
-    voiceButton.textContent = 'Voice Unavailable';
     voiceButton.disabled = true;
     voiceButton.setAttribute('aria-pressed', 'false');
     voiceButton.setAttribute('aria-disabled', 'true');
+    voiceButton.classList.remove('is-on');
+    setActiveState('unavailable');
+    const label = 'Voice unavailable';
+    voiceButton.setAttribute('aria-label', label);
+    if(labelEl){
+      labelEl.textContent = label;
+    }
     if(voiceInfo){
       voiceInfo.hidden = false;
     }
@@ -491,8 +515,15 @@ function updateVoiceButton(){
   } else {
     voiceButton.removeAttribute('aria-disabled');
   }
-  voiceButton.textContent = viewerState.isVoiceOn ? 'Voice On' : 'Voice Off';
-  voiceButton.setAttribute('aria-pressed', viewerState.isVoiceOn ? 'true' : 'false');
+  const isOn = !!viewerState.isVoiceOn && viewerState.isVoiceSupported;
+  voiceButton.setAttribute('aria-pressed', isOn ? 'true' : 'false');
+  voiceButton.classList.toggle('is-on', isOn);
+  setActiveState(isOn ? 'on' : 'off');
+  const label = isOn ? 'Voice on' : 'Voice off';
+  voiceButton.setAttribute('aria-label', label);
+  if(labelEl){
+    labelEl.textContent = label;
+  }
   if(voiceInfo){
     voiceInfo.hidden = true;
   }


### PR DESCRIPTION
## Summary
- replace the voice toggle text label with stateful icons and an sr-only label
- style the voice control button to match the other icon controls and hide inactive icons
- update the voice button logic to toggle icons, aria labels, and disabled states without replacing markup

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2d3e47b58832d8254ab8a5af30f62