### PR TITLE
Add save workflow for projects

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,6 +79,16 @@
     <div class="panel">
       <div class="e4-board-wrap">
         <div class="e4-toolbar">
+          <button id="save-project" class="icon-btn">
+            <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+              <g fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M5 7a2 2 0 0 1 2-2h10l2 2v12a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2Z"/>
+                <path d="M9 7V5h6v4H9Z"/>
+                <path d="M9 15h6"/>
+              </g>
+            </svg>
+            <span class="sr-only">Save project</span>
+          </button>
           <button id="exp-png" class="good icon-btn">
             <svg aria-hidden="true" viewBox="0 0 32 32" focusable="false">
               <g fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">


### PR DESCRIPTION
## Summary
- add a save button to the viewer toolbar and gate exports until a project is saved
- mark newly created projects as unsaved and only persist metadata for saved projects
- refresh project metadata and the list when projects are saved or updated so existing entries remain usable

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d2f31424c8832d98d490c377a2eadb