### PR TITLE
Navigate to viewer when selecting saved project

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -654,7 +654,12 @@ function refreshProjectList(){
   State.listProjects().filter(p=>projectIsSaved(p)).forEach(p=>{
     const li=document.createElement('li');
     li.innerHTML=`<span>${p.name}</span><span class="tiny">${new Date(p.updatedAt).toLocaleString()}</span>`;
-    li.addEventListener('click', ()=>{ State.setProject(p); hydrateProjectView(); refreshProjectList(); State.go(3); });
+    li.addEventListener('click', ()=>{
+      State.setProject(p);
+      hydrateProjectView();
+      State.go(4);
+      refreshProjectList();
+    });
     ul.appendChild(li);
   });
 }


### PR DESCRIPTION
## Summary
- change saved project selection to send users to the E4 viewer after hydrating the project

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d30018e1a0832da1b3f4076814d713