### PR TITLE
Redesign home screen and saved project management

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -28,6 +28,56 @@ canvas{display:block;width:100%;height:auto;border-radius:12px;background:#111}
 .hint{color:var(--muted);font-size:12px}
 .tiny{color:var(--muted);font-size:12px}
 
+/* E1 */
+#screen-1{min-height:100vh;display:flex;align-items:center;justify-content:center;padding:32px 16px 140px}
+#screen-1 .e1-stage{width:100%;max-width:520px;position:relative;display:flex;align-items:center;justify-content:center}
+#screen-1 .e1-home{display:flex;flex-direction:column;align-items:center;justify-content:center;gap:20px;text-align:center;padding:28px 24px;background:color-mix(in srgb, var(--panel) 82%, transparent);border:1px solid color-mix(in srgb, var(--ring) 65%, transparent);border-radius:20px;box-shadow:0 22px 46px rgba(0,0,0,.45);min-width:min(100%,420px)}
+#screen-1 .e1-home.is-hidden{visibility:hidden;pointer-events:none}
+#screen-1 .e1-home-heading{display:flex;flex-direction:column;gap:8px}
+#screen-1 .e1-title{margin:0;font-size:28px;font-weight:700;letter-spacing:.02em}
+#screen-1 .e1-subtitle{margin:0;color:var(--muted);font-size:14px}
+#screen-1 .e1-actions{display:flex;flex-direction:column;gap:12px;width:100%}
+#screen-1 .e1-actions button{width:100%;padding:16px 18px;border-radius:14px;font-size:16px}
+#screen-1 .e1-actions button:not(.primary){background:color-mix(in srgb, #101522 92%, transparent);border:1px solid color-mix(in srgb, var(--ring) 70%, transparent);color:var(--text)}
+#screen-1 .e1-hint{color:var(--muted);font-size:12px}
+#screen-1 .e1-projects{position:absolute;inset:0;display:flex;flex-direction:column;background:color-mix(in srgb, var(--panel) 90%, transparent);border:1px solid color-mix(in srgb, var(--ring) 65%, transparent);border-radius:20px;box-shadow:0 24px 54px rgba(0,0,0,.48);padding:24px}
+#screen-1 .e1-projects[hidden]{display:none}
+#screen-1 .e1-projects-header{display:flex;align-items:center;justify-content:space-between;gap:16px;margin-bottom:12px}
+#screen-1 .e1-projects-title{margin:0;font-size:22px;font-weight:700}
+#screen-1 .e1-back-btn{display:inline-flex;align-items:center;justify-content:center;width:42px;height:42px;border-radius:12px;padding:0;background:color-mix(in srgb, #101522 88%, transparent);border:1px solid color-mix(in srgb, var(--ring) 70%, transparent);color:var(--text);transition:color .18s ease, border-color .18s ease, background-color .18s ease}
+#screen-1 .e1-back-btn svg{width:22px;height:22px;transform:scaleX(-1)}
+#screen-1 .e1-back-btn:hover,#screen-1 .e1-back-btn:focus-visible{color:var(--brand);border-color:color-mix(in srgb, var(--brand) 45%, transparent);outline:none}
+#screen-1 .e1-projects-body{flex:1;min-height:0;overflow-y:auto;padding-right:4px;margin-right:-4px}
+#screen-1 .project-cards{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:12px}
+#screen-1 .project-card{display:flex;align-items:center;gap:12px;border-radius:16px;background:color-mix(in srgb, #101522 94%, transparent);border:1px solid color-mix(in srgb, var(--ring) 65%, transparent);padding:12px 14px;box-shadow:0 10px 24px rgba(0,0,0,.35)}
+#screen-1 .project-card-main{flex:1;display:flex;align-items:center;gap:12px;border:none;background:none;color:inherit;padding:0;text-align:left;cursor:pointer}
+#screen-1 .project-card-main:focus-visible{outline:2px solid var(--brand);outline-offset:4px;border-radius:14px}
+#screen-1 .project-card-thumb{width:64px;height:64px;border-radius:50%;overflow:hidden;background:color-mix(in srgb, #0f1320 92%, transparent);display:flex;align-items:center;justify-content:center;flex-shrink:0;position:relative}
+#screen-1 .project-card-thumb img{width:100%;height:100%;object-fit:cover;display:block}
+#screen-1 .project-card-info{display:flex;flex-direction:column;gap:4px;min-width:0}
+#screen-1 .project-card-name{font-weight:600;font-size:16px;line-height:1.2;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+#screen-1 .project-card-meta{font-size:13px;color:var(--muted)}
+#screen-1 .project-card-menu{position:relative;display:flex;align-items:center;justify-content:center}
+#screen-1 .project-card-menu-btn{width:40px;height:40px;border-radius:12px;padding:0;display:inline-flex;align-items:center;justify-content:center;background:color-mix(in srgb, #101522 88%, transparent);border:1px solid transparent;color:var(--muted);cursor:pointer;transition:color .18s ease, background-color .18s ease, border-color .18s ease}
+#screen-1 .project-card-menu-btn svg{width:20px;height:20px}
+#screen-1 .project-card-menu.is-open .project-card-menu-btn,#screen-1 .project-card-menu-btn:hover,#screen-1 .project-card-menu-btn:focus-visible{color:var(--text);border-color:color-mix(in srgb, var(--brand) 45%, transparent);outline:none}
+#screen-1 .project-card-menu-list{position:absolute;top:calc(100% + 6px);right:0;min-width:184px;display:flex;flex-direction:column;gap:4px;padding:6px;border-radius:14px;background:color-mix(in srgb, #0f1320 96%, transparent);border:1px solid color-mix(in srgb, var(--ring) 75%, transparent);box-shadow:0 20px 46px rgba(0,0,0,.5);opacity:0;visibility:hidden;transform:translateY(-6px);transition:opacity .16s ease, transform .16s ease, visibility .16s ease;z-index:30}
+#screen-1 .project-card-menu.is-open .project-card-menu-list{opacity:1;visibility:visible;transform:translateY(0)}
+#screen-1 .project-card-menu-list button{width:100%;text-align:left;padding:10px 12px;border-radius:10px;border:1px solid transparent;background:color-mix(in srgb, #131a2a 90%, transparent);color:var(--text);font-weight:600;cursor:pointer}
+#screen-1 .project-card-menu-list button:hover,#screen-1 .project-card-menu-list button:focus-visible{background:color-mix(in srgb, var(--brand) 25%, #131a2a 75%);border-color:color-mix(in srgb, var(--brand) 45%, transparent);outline:none}
+#screen-1 .project-card-menu-list button.is-danger{color:color-mix(in srgb, #fda4af 80%, var(--text) 20%)}
+#screen-1 .project-card-menu-list button.is-danger:hover,#screen-1 .project-card-menu-list button.is-danger:focus-visible{background:color-mix(in srgb, #7a2a2a 40%, #131a2a 60%);border-color:color-mix(in srgb, #ef4444 45%, transparent)}
+#screen-1 .project-list-empty{margin-top:40px;text-align:center;color:var(--muted);font-size:13px}
+
+@media(max-width:600px){
+  #screen-1{padding:24px 12px 130px}
+  #screen-1 .e1-home{padding:24px 20px}
+  #screen-1 .e1-projects{padding:20px 16px}
+  #screen-1 .project-card{flex-direction:column;align-items:flex-start}
+  #screen-1 .project-card-main{width:100%}
+  #screen-1 .project-card-menu{align-self:flex-end}
+}
+
 /* Sabit alt sekme çubuğu */
 .app-nav{position:fixed;bottom:0;left:0;right:0;z-index:10;display:flex;gap:8px;justify-content:space-around;padding:10px 12px calc(10px + env(safe-area-inset-bottom,0));background-color:color-mix(in srgb, var(--panel) 92%, transparent);backdrop-filter:blur(12px);border-top:1px solid var(--ring)}
 .app-nav button{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:6px;padding:10px 12px;border-radius:14px;background:color-mix(in srgb, #101522 92%, transparent);border:1px solid transparent;color:var(--muted);font-size:11px;text-transform:uppercase;letter-spacing:0.05em;font-weight:600;transition:color .2s ease, background-color .2s ease, border-color .2s ease}

--- a/index.html
+++ b/index.html
@@ -10,14 +10,35 @@
 <body>
 <main id="app">
   <section id="screen-1" class="screen" role="region" aria-label="Home">
-    <div class="panel">
-      <h2>New project</h2>
-      <input id="e1-file" type="file" accept="image/*"/>
-      <div class="hint">Pick an image to start.</div>
-    </div>
-    <div class="panel">
-      <h2>My projects</h2>
-      <ul id="project-list" class="list"></ul>
+    <div class="e1-stage">
+      <div id="e1-home" class="e1-home">
+        <div class="e1-home-heading">
+          <h1 class="e1-title">String Art Studio</h1>
+          <p class="e1-subtitle">Start a new project or pick up where you left off.</p>
+        </div>
+        <div class="e1-actions">
+          <button id="e1-start" class="primary" type="button">New project</button>
+          <button id="e1-open" type="button">Saved projects</button>
+        </div>
+        <div class="e1-hint">Images stay on this device.</div>
+      </div>
+
+      <div id="e1-projects" class="e1-projects" hidden>
+        <header class="e1-projects-header">
+          <h2 class="e1-projects-title">Saved projects</h2>
+          <button id="e1-back" class="e1-back-btn" type="button">
+            <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+              <path d="m8 5 8 7-8 7" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            <span class="sr-only">Back to home</span>
+          </button>
+        </header>
+        <div class="e1-projects-body">
+          <ul id="project-list" class="project-cards" aria-label="Saved projects"></ul>
+          <div id="project-list-empty" class="project-list-empty" hidden>No saved projects yet. Generate and save one from the viewer to see it here.</div>
+        </div>
+      </div>
+      <input id="e1-file" type="file" accept="image/*" hidden/>
     </div>
   </section>
 

--- a/js/state.js
+++ b/js/state.js
@@ -1,4 +1,4 @@
-import { idbPutBlob, idbGetBlob } from './utils.js';
+import { idbPutBlob, idbGetBlob, idbDeleteBlob } from './utils.js';
 const LS_KEY = 'sa.projects.v1';
 const state = { screen: 1, project: null };
 const navigateListeners = new Set();
@@ -22,6 +22,24 @@ function normalizeProject(proj){
   return normalized;
 }
 
+function readStoredProjects(){
+  const raw = localStorage.getItem(LS_KEY);
+  if(!raw) return [];
+  try{
+    const parsed = JSON.parse(raw);
+    if(!Array.isArray(parsed)) return [];
+    return parsed;
+  }catch(err){
+    console.error('Failed to parse stored projects', err);
+    return [];
+  }
+}
+
+function writeStoredProjects(list){
+  const normalized = list.map(normalizeProject).filter(Boolean);
+  localStorage.setItem(LS_KEY, JSON.stringify(normalized.slice(0,50)));
+}
+
 export function newProjectFromImage(file){
   const id = 'p_' + Date.now().toString(36);
   const proj = { id, name: file.name || 'Untitled', createdAt: Date.now(), updatedAt: Date.now(),
@@ -40,26 +58,62 @@ export function setProject(proj){
   persistMeta();
 }
 export function listProjects(){
-  const raw = localStorage.getItem(LS_KEY);
-  if(!raw) return [];
-  try{
-    const parsed = JSON.parse(raw);
-    if(!Array.isArray(parsed)) return [];
-    return parsed.map(normalizeProject).filter(Boolean);
-  }catch(err){
-    console.error('Failed to parse stored projects', err);
-    return [];
-  }
+  return readStoredProjects().map(normalizeProject).filter(Boolean);
 }
 export function persistMeta(){
   const current = state.project;
   const currentId = current?.id;
-  const list = listProjects().filter(p=>p.id !== currentId);
+  const stored = readStoredProjects().filter(p=>p?.id !== currentId);
   if(current && current.isSaved !== false){
-    list.unshift(normalizeProject(current));
+    stored.unshift(normalizeProject(current));
   }
-  localStorage.setItem(LS_KEY, JSON.stringify(list.slice(0,50)));
+  writeStoredProjects(stored);
 }
 export async function saveRasterBlob(id, blob){ await idbPutBlob(id, blob); }
 export async function loadRasterBlob(id){ return await idbGetBlob(id); }
 export function get(){ return state; }
+
+export function renameProject(id, name){
+  const trimmed = (name ?? '').trim();
+  if(!id || !trimmed) return null;
+  const stored = readStoredProjects();
+  let updated = null;
+  const next = stored.map(proj=>{
+    if(proj?.id === id){
+      const update = { ...proj, name: trimmed, updatedAt: Date.now() };
+      updated = update;
+      return update;
+    }
+    return proj;
+  });
+  if(!updated){
+    return null;
+  }
+  writeStoredProjects(next);
+  if(state.project?.id === id){
+    state.project.name = trimmed;
+    state.project.updatedAt = updated.updatedAt;
+  }
+  return normalizeProject(updated);
+}
+
+export async function deleteProject(id){
+  if(!id) return false;
+  const stored = readStoredProjects();
+  const index = stored.findIndex(proj=>proj?.id === id);
+  if(index < 0) return false;
+  const [removed] = stored.splice(index, 1);
+  writeStoredProjects(stored);
+  if(removed?.rasterBlobId){
+    try{
+      await idbDeleteBlob(removed.rasterBlobId);
+    }catch(err){
+      console.error('Failed to remove raster blob for project', err);
+    }
+  }
+  if(state.project?.id === id){
+    state.project = null;
+  }
+  persistMeta();
+  return true;
+}

--- a/js/ui.js
+++ b/js/ui.js
@@ -8,6 +8,23 @@ const DEFAULT_SPEED_INDEX = 2;
 let navButtons = [];
 let removeNavigateListener = null;
 
+const projectPreviewCache = new Map();
+const e1UI = {
+  home: null,
+  projects: null,
+  fileInput: null,
+  startButton: null,
+  openButton: null,
+  backButton: null,
+  list: null,
+  empty: null,
+};
+let isProjectListOpen = false;
+let projectListKeyHandler = null;
+let openProjectMenu = null;
+let projectMenuOutsideHandler = null;
+let projectMenuKeyHandler = null;
+
 let crop = { img:null, scale:1, tx:0, ty:0, rot:0, down:false, lx:0, ly:0, displaySize:0 };
 
 let viewerResizeObserver = null;
@@ -624,8 +641,47 @@ export function mount(){
   setActiveNav(State.get().screen);
   if(removeNavigateListener) removeNavigateListener();
   removeNavigateListener = State.onNavigate(setActiveNav);
-  const file = document.getElementById('e1-file'); file.addEventListener('change', onPickImage);
-  refreshProjectList(); bindCrop(); bindGenerate(); bindViewer();
+  setupHomeScreen();
+  bindCrop(); bindGenerate(); bindViewer();
+}
+
+function setupHomeScreen(){
+  e1UI.home = document.getElementById('e1-home');
+  e1UI.projects = document.getElementById('e1-projects');
+  e1UI.fileInput = document.getElementById('e1-file');
+  e1UI.startButton = document.getElementById('e1-start');
+  e1UI.openButton = document.getElementById('e1-open');
+  e1UI.backButton = document.getElementById('e1-back');
+  e1UI.list = document.getElementById('project-list');
+  e1UI.empty = document.getElementById('project-list-empty');
+
+  const { fileInput, startButton, openButton, backButton } = e1UI;
+
+  if(fileInput){
+    fileInput.addEventListener('change', onPickImage);
+  }
+  if(startButton){
+    startButton.addEventListener('click', ()=>{
+      if(!fileInput) return;
+      try{ fileInput.value = ''; }
+      catch(err){ /* ignore */ }
+      fileInput.click();
+    });
+  }
+  if(openButton){
+    openButton.addEventListener('click', ()=>{
+      showProjectList();
+    });
+  }
+  if(backButton){
+    backButton.addEventListener('click', ()=>{
+      hideProjectList();
+      if(openButton) openButton.focus();
+    });
+  }
+
+  hideProjectList();
+  refreshProjectList();
 }
 
 function setActiveNav(screenId){
@@ -649,19 +705,350 @@ function setActiveNav(screenId){
   }
 }
 
+function showProjectList(){
+  if(isProjectListOpen) return;
+  isProjectListOpen = true;
+  if(e1UI.projects){
+    e1UI.projects.hidden = false;
+    e1UI.projects.setAttribute('aria-hidden', 'false');
+  }
+  if(e1UI.home){
+    e1UI.home.classList.add('is-hidden');
+    e1UI.home.setAttribute('aria-hidden', 'true');
+  }
+  refreshProjectList();
+  if(projectListKeyHandler){
+    document.removeEventListener('keydown', projectListKeyHandler);
+  }
+  projectListKeyHandler = event=>{
+    if(event.key === 'Escape'){
+      if(openProjectMenu){
+        return;
+      }
+      event.preventDefault();
+      hideProjectList();
+      const btn = e1UI.openButton;
+      if(btn) btn.focus();
+    }
+  };
+  document.addEventListener('keydown', projectListKeyHandler);
+  if(e1UI.backButton){
+    e1UI.backButton.focus();
+  }
+}
+
+function hideProjectList(){
+  isProjectListOpen = false;
+  if(e1UI.projects){
+    e1UI.projects.hidden = true;
+    e1UI.projects.setAttribute('aria-hidden', 'true');
+  }
+  if(e1UI.home){
+    e1UI.home.classList.remove('is-hidden');
+    e1UI.home.removeAttribute('aria-hidden');
+  }
+  closeOpenProjectMenu();
+  if(projectListKeyHandler){
+    document.removeEventListener('keydown', projectListKeyHandler);
+    projectListKeyHandler = null;
+  }
+}
+
 function refreshProjectList(){
-  const ul = document.getElementById('project-list'); ul.innerHTML = '';
-  State.listProjects().filter(p=>projectIsSaved(p)).forEach(p=>{
-    const li=document.createElement('li');
-    li.innerHTML=`<span>${p.name}</span><span class="tiny">${new Date(p.updatedAt).toLocaleString()}</span>`;
-    li.addEventListener('click', ()=>{
-      State.setProject(p);
-      hydrateProjectView();
-      State.go(4);
-      refreshProjectList();
-    });
-    ul.appendChild(li);
+  const list = e1UI.list || document.getElementById('project-list');
+  if(!list) return;
+  closeOpenProjectMenu();
+  list.innerHTML = '';
+  const projects = State.listProjects().filter(projectIsSaved);
+  if(e1UI.empty){
+    e1UI.empty.hidden = projects.length > 0;
+  }
+  if(projects.length === 0){
+    return;
+  }
+  const frag = document.createDocumentFragment();
+  projects.forEach(proj=>{
+    const item = createProjectListItem(proj);
+    frag.appendChild(item);
+    loadProjectPreview(item, proj);
   });
+  list.appendChild(frag);
+}
+
+function createProjectListItem(proj){
+  const li = document.createElement('li');
+  li.className = 'project-card';
+  li.dataset.projectId = proj.id;
+
+  const mainButton = document.createElement('button');
+  mainButton.type = 'button';
+  mainButton.className = 'project-card-main';
+  mainButton.addEventListener('click', ()=>{
+    closeOpenProjectMenu();
+    resumeSavedProject(proj);
+  });
+
+  const thumb = document.createElement('div');
+  thumb.className = 'project-card-thumb';
+  const img = document.createElement('img');
+  img.alt = '';
+  img.loading = 'lazy';
+  img.decoding = 'async';
+  img.dataset.projectId = proj.id;
+  thumb.appendChild(img);
+
+  const info = document.createElement('div');
+  info.className = 'project-card-info';
+  const name = document.createElement('div');
+  name.className = 'project-card-name';
+  name.textContent = (proj.name || '').trim() || 'Untitled';
+  const meta = document.createElement('div');
+  meta.className = 'project-card-meta';
+  meta.textContent = formatProjectStepLabel(proj);
+  info.append(name, meta);
+
+  mainButton.append(thumb, info);
+  li.appendChild(mainButton);
+
+  const menuWrap = document.createElement('div');
+  menuWrap.className = 'project-card-menu';
+  const menuButton = document.createElement('button');
+  menuButton.type = 'button';
+  menuButton.className = 'project-card-menu-btn';
+  menuButton.setAttribute('aria-haspopup', 'true');
+  menuButton.setAttribute('aria-expanded', 'false');
+  menuButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" focusable="false"><circle cx="5" cy="12" r="1.6"/><circle cx="12" cy="12" r="1.6"/><circle cx="19" cy="12" r="1.6"/></svg><span class="sr-only">Project options</span>';
+  menuButton.addEventListener('click', event=>{
+    event.preventDefault();
+    event.stopPropagation();
+    const willOpen = !menuWrap.classList.contains('is-open');
+    setProjectMenuOpen(menuWrap, willOpen);
+  });
+
+  const menuList = document.createElement('div');
+  menuList.className = 'project-card-menu-list';
+  menuList.setAttribute('role', 'menu');
+  menuList.setAttribute('aria-hidden', 'true');
+
+  [
+    { action:'resume', label:'Continue project' },
+    { action:'rename', label:'Rename' },
+    { action:'delete', label:'Delete', destructive:true },
+  ].forEach(({action, label, destructive})=>{
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.dataset.action = action;
+    btn.textContent = label;
+    btn.setAttribute('role', 'menuitem');
+    btn.tabIndex = -1;
+    if(destructive) btn.classList.add('is-danger');
+    btn.addEventListener('click', async evt=>{
+      evt.preventDefault();
+      evt.stopPropagation();
+      closeOpenProjectMenu();
+      await handleProjectMenuAction(action, proj);
+    });
+    menuList.appendChild(btn);
+  });
+
+  menuWrap.append(menuButton, menuList);
+  li.appendChild(menuWrap);
+
+  return li;
+}
+
+function formatProjectStepLabel(proj){
+  const total = Number.isFinite(proj.stepCount) ? Math.max(0, Math.floor(proj.stepCount)) : 0;
+  const last = Number.isFinite(proj.lastViewedStep) ? Math.max(0, Math.floor(proj.lastViewedStep)) : 0;
+  const current = total > 0 ? Math.min(last + 1, total) : 0;
+  const currentLabel = current.toLocaleString();
+  const totalLabel = total.toLocaleString();
+  return `Current step ${currentLabel} / ${totalLabel}`;
+}
+
+function resumeSavedProject(proj){
+  if(!proj) return;
+  const resume = { ...proj, updatedAt: Date.now() };
+  State.setProject(resume);
+  hydrateProjectView();
+  State.go(4);
+  hideProjectList();
+  refreshProjectList();
+}
+
+async function handleProjectMenuAction(action, proj){
+  if(action === 'resume'){
+    resumeSavedProject(proj);
+    return;
+  }
+  if(action === 'rename'){
+    const currentName = (proj.name || '').trim() || 'Untitled';
+    const input = prompt('Rename project', currentName);
+    if(input === null) return;
+    const trimmed = input.trim();
+    if(!trimmed || trimmed === currentName) return;
+    const updated = State.renameProject(proj.id, trimmed);
+    if(updated){
+      refreshProjectList();
+      syncProjectMetaUI();
+    }
+    return;
+  }
+  if(action === 'delete'){
+    const confirmed = confirm('Delete this project? This cannot be undone.');
+    if(!confirmed) return;
+    const success = await State.deleteProject(proj.id);
+    if(success){
+      projectPreviewCache.delete(proj.id);
+      refreshProjectList();
+      syncProjectMetaUI();
+    }
+  }
+}
+
+function setProjectMenuOpen(wrapper, open){
+  if(!wrapper) return;
+  const trigger = wrapper.querySelector('.project-card-menu-btn');
+  const menu = wrapper.querySelector('.project-card-menu-list');
+  if(!trigger || !menu) return;
+
+  if(open){
+    if(openProjectMenu && openProjectMenu !== wrapper){
+      setProjectMenuOpen(openProjectMenu, false);
+    }
+    wrapper.classList.add('is-open');
+    trigger.setAttribute('aria-expanded', 'true');
+    menu.setAttribute('aria-hidden', 'false');
+    menu.querySelectorAll('button').forEach(btn=>{ btn.tabIndex = 0; });
+    openProjectMenu = wrapper;
+    if(projectMenuOutsideHandler){
+      document.removeEventListener('pointerdown', projectMenuOutsideHandler);
+    }
+    if(projectMenuKeyHandler){
+      document.removeEventListener('keydown', projectMenuKeyHandler);
+    }
+    projectMenuOutsideHandler = event=>{
+      if(!wrapper.contains(event.target)){
+        setProjectMenuOpen(wrapper, false);
+      }
+    };
+    projectMenuKeyHandler = event=>{
+      if(event.key === 'Escape'){
+        event.preventDefault();
+        setProjectMenuOpen(wrapper, false);
+        trigger.focus();
+      }
+    };
+    document.addEventListener('pointerdown', projectMenuOutsideHandler);
+    document.addEventListener('keydown', projectMenuKeyHandler);
+    const first = menu.querySelector('button');
+    if(first){
+      setTimeout(()=>first.focus(), 0);
+    }
+  } else {
+    wrapper.classList.remove('is-open');
+    trigger.setAttribute('aria-expanded', 'false');
+    menu.setAttribute('aria-hidden', 'true');
+    menu.querySelectorAll('button').forEach(btn=>{ btn.tabIndex = -1; });
+    if(openProjectMenu === wrapper){
+      openProjectMenu = null;
+      if(projectMenuOutsideHandler){
+        document.removeEventListener('pointerdown', projectMenuOutsideHandler);
+        projectMenuOutsideHandler = null;
+      }
+      if(projectMenuKeyHandler){
+        document.removeEventListener('keydown', projectMenuKeyHandler);
+        projectMenuKeyHandler = null;
+      }
+    }
+  }
+}
+
+function closeOpenProjectMenu(){
+  if(openProjectMenu){
+    setProjectMenuOpen(openProjectMenu, false);
+  }
+}
+
+function loadProjectPreview(item, proj){
+  const img = item.querySelector('.project-card-thumb img');
+  if(!img) return;
+  img.dataset.projectId = proj.id;
+  const cached = projectPreviewCache.get(proj.id);
+  if(cached !== undefined){
+    if(typeof cached === 'string' && cached){
+      img.src = cached;
+    } else {
+      img.removeAttribute('src');
+    }
+    return;
+  }
+  ensureProjectPreview(proj).then(url=>{
+    if(img.dataset.projectId !== proj.id) return;
+    if(url){
+      img.src = url;
+    } else {
+      img.removeAttribute('src');
+    }
+  });
+}
+
+async function ensureProjectPreview(proj){
+  if(!proj || !proj.id) return null;
+  if(projectPreviewCache.has(proj.id)){
+    return projectPreviewCache.get(proj.id) || null;
+  }
+  if(!proj.rasterBlobId){
+    projectPreviewCache.set(proj.id, null);
+    return null;
+  }
+  try{
+    const blob = await State.loadRasterBlob(proj.rasterBlobId);
+    if(!blob){
+      projectPreviewCache.set(proj.id, null);
+      return null;
+    }
+    const buffer = await blob.arrayBuffer();
+    const bytes = new Uint8Array(buffer);
+    const resolvedSize = Number.isFinite(proj.size) && proj.size>0 ? proj.size : Math.round(Math.sqrt(bytes.length));
+    if(!Number.isFinite(resolvedSize) || resolvedSize<=0){
+      projectPreviewCache.set(proj.id, null);
+      return null;
+    }
+    const dim = Math.max(32, Math.min(120, resolvedSize));
+    const canvas = document.createElement('canvas');
+    canvas.width = dim;
+    canvas.height = dim;
+    const ctx = canvas.getContext('2d');
+    if(!ctx){
+      projectPreviewCache.set(proj.id, null);
+      return null;
+    }
+    const imageData = ctx.createImageData(dim, dim);
+    const data = imageData.data;
+    const ratio = resolvedSize / dim;
+    for(let y=0; y<dim; y++){
+      const srcY = Math.min(resolvedSize - 1, Math.floor(y * ratio));
+      for(let x=0; x<dim; x++){
+        const srcX = Math.min(resolvedSize - 1, Math.floor(x * ratio));
+        const srcIndex = srcY * resolvedSize + srcX;
+        const gray = bytes[srcIndex] ?? 0;
+        const dst = (y * dim + x) * 4;
+        data[dst] = gray;
+        data[dst+1] = gray;
+        data[dst+2] = gray;
+        data[dst+3] = 255;
+      }
+    }
+    ctx.putImageData(imageData, 0, 0);
+    const url = canvas.toDataURL('image/png');
+    projectPreviewCache.set(proj.id, url);
+    return url;
+  }catch(err){
+    console.error('Failed to build project preview', err);
+    projectPreviewCache.set(proj.id, null);
+    return null;
+  }
 }
 
 function hydrateProjectView(){

--- a/js/utils.js
+++ b/js/utils.js
@@ -35,3 +35,7 @@ function withDB(mode, fn){
 }
 export async function idbPutBlob(key, blob){ return withDB('readwrite', s=>s.put(blob, key)); }
 export async function idbGetBlob(key){ return withDB('readonly', s=>new Promise((res,rej)=>{ const r = s.get(key); r.onsuccess=()=>res(r.result||null); r.onerror=()=>rej(r.error); })); }
+export async function idbDeleteBlob(key){
+  if(!key) return;
+  return withDB('readwrite', s=>s.delete(key));
+}


### PR DESCRIPTION
## Summary
- redesign the E1 home screen into a centered layout with primary actions and an overlay for browsing saved projects
- add saved project cards with inline metadata, thumbnail previews, and a contextual menu to resume, rename, or delete
- extend state persistence to support renaming/deleting projects and clean up stored raster blobs

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d3cfbc2c78832d9d5daaa1b40d6fad