### PR TITLE
Adjust saved projects layout and menu styling

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -31,7 +31,7 @@ canvas{display:block;width:100%;height:auto;border-radius:12px;background:#111}
 /* E1 */
 #screen-1{min-height:100vh;padding:32px 16px 140px}
 #screen-1.active{display:flex;align-items:center;justify-content:center}
-#screen-1 .e1-stage{width:100%;max-width:520px;position:relative;display:flex;align-items:center;justify-content:center}
+#screen-1 .e1-stage{width:100%;max-width:520px;position:relative;display:flex;align-items:center;justify-content:center;min-height:min(620px,90vh)}
 #screen-1 .e1-home{display:flex;flex-direction:column;align-items:center;justify-content:center;gap:20px;text-align:center;padding:28px 24px;background:color-mix(in srgb, var(--panel) 82%, transparent);border:1px solid color-mix(in srgb, var(--ring) 65%, transparent);border-radius:20px;box-shadow:0 22px 46px rgba(0,0,0,.45);min-width:min(100%,420px)}
 #screen-1 .e1-home.is-hidden{visibility:hidden;pointer-events:none}
 #screen-1 .e1-home-heading{display:flex;flex-direction:column;gap:8px}
@@ -41,11 +41,12 @@ canvas{display:block;width:100%;height:auto;border-radius:12px;background:#111}
 #screen-1 .e1-actions button{width:100%;padding:16px 18px;border-radius:14px;font-size:16px}
 #screen-1 .e1-actions button:not(.primary){background:color-mix(in srgb, #101522 92%, transparent);border:1px solid color-mix(in srgb, var(--ring) 70%, transparent);color:var(--text)}
 #screen-1 .e1-hint{color:var(--muted);font-size:12px}
-#screen-1 .e1-projects{position:absolute;inset:0;display:flex;flex-direction:column;background:color-mix(in srgb, var(--panel) 90%, transparent);border:1px solid color-mix(in srgb, var(--ring) 65%, transparent);border-radius:20px;box-shadow:0 24px 54px rgba(0,0,0,.48);padding:24px}
+#screen-1 .e1-projects{position:absolute;inset:0;display:flex;flex-direction:column;background:color-mix(in srgb, var(--panel) 90%, transparent);border:1px solid color-mix(in srgb, var(--ring) 65%, transparent);border-radius:20px;box-shadow:0 24px 54px rgba(0,0,0,.48);padding:24px;min-height:min(560px,85vh)}
 #screen-1 .e1-projects[hidden]{display:none}
-#screen-1 .e1-projects-header{display:flex;align-items:center;justify-content:space-between;gap:16px;margin-bottom:12px}
+#screen-1 .e1-projects-header{position:relative;display:flex;align-items:center;justify-content:center;gap:16px;margin-bottom:12px;padding:0 56px}
 #screen-1 .e1-projects-title{margin:0;font-size:22px;font-weight:700}
-#screen-1 .e1-back-btn{display:inline-flex;align-items:center;justify-content:center;width:42px;height:42px;border-radius:12px;padding:0;background:color-mix(in srgb, #101522 88%, transparent);border:1px solid color-mix(in srgb, var(--ring) 70%, transparent);color:var(--text);transition:color .18s ease, border-color .18s ease, background-color .18s ease}
+#screen-1 .e1-projects-title{text-align:center}
+#screen-1 .e1-back-btn{position:absolute;left:0;display:inline-flex;align-items:center;justify-content:center;width:42px;height:42px;border-radius:12px;padding:0;background:color-mix(in srgb, #101522 88%, transparent);border:1px solid color-mix(in srgb, var(--ring) 70%, transparent);color:var(--text);transition:color .18s ease, border-color .18s ease, background-color .18s ease}
 #screen-1 .e1-back-btn svg{width:22px;height:22px;transform:scaleX(-1)}
 #screen-1 .e1-back-btn:hover,#screen-1 .e1-back-btn:focus-visible{color:var(--brand);border-color:color-mix(in srgb, var(--brand) 45%, transparent);outline:none}
 #screen-1 .e1-projects-body{flex:1;min-height:0;overflow-y:auto;padding-right:4px;margin-right:-4px}
@@ -59,8 +60,9 @@ canvas{display:block;width:100%;height:auto;border-radius:12px;background:#111}
 #screen-1 .project-card-name{font-weight:600;font-size:16px;line-height:1.2;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 #screen-1 .project-card-meta{font-size:13px;color:var(--muted)}
 #screen-1 .project-card-menu{position:relative;display:flex;align-items:center;justify-content:center}
-#screen-1 .project-card-menu-btn{width:40px;height:40px;border-radius:12px;padding:0;display:inline-flex;align-items:center;justify-content:center;background:color-mix(in srgb, #101522 88%, transparent);border:1px solid transparent;color:var(--muted);cursor:pointer;transition:color .18s ease, background-color .18s ease, border-color .18s ease}
+#screen-1 .project-card-menu-btn{width:40px;height:40px;border-radius:12px;padding:0;display:inline-flex;align-items:center;justify-content:center;background:color-mix(in srgb, #101522 82%, transparent);border:1px solid transparent;color:color-mix(in srgb, var(--text) 75%, var(--brand) 25%);cursor:pointer;transition:color .18s ease, background-color .18s ease, border-color .18s ease}
 #screen-1 .project-card-menu-btn svg{width:20px;height:20px}
+#screen-1 .project-card-menu-btn svg circle{fill:currentColor}
 #screen-1 .project-card-menu.is-open .project-card-menu-btn,#screen-1 .project-card-menu-btn:hover,#screen-1 .project-card-menu-btn:focus-visible{color:var(--text);border-color:color-mix(in srgb, var(--brand) 45%, transparent);outline:none}
 #screen-1 .project-card-menu-list{position:absolute;top:calc(100% + 6px);right:0;min-width:184px;display:flex;flex-direction:column;gap:4px;padding:6px;border-radius:14px;background:color-mix(in srgb, #0f1320 96%, transparent);border:1px solid color-mix(in srgb, var(--ring) 75%, transparent);box-shadow:0 20px 46px rgba(0,0,0,.5);opacity:0;visibility:hidden;transform:translateY(-6px);transition:opacity .16s ease, transform .16s ease, visibility .16s ease;z-index:30}
 #screen-1 .project-card-menu.is-open .project-card-menu-list{opacity:1;visibility:visible;transform:translateY(0)}
@@ -73,7 +75,9 @@ canvas{display:block;width:100%;height:auto;border-radius:12px;background:#111}
 @media(max-width:600px){
   #screen-1{padding:24px 12px 130px}
   #screen-1 .e1-home{padding:24px 20px}
-  #screen-1 .e1-projects{padding:20px 16px}
+  #screen-1 .e1-stage{min-height:calc(100vh - 48px)}
+  #screen-1 .e1-projects{padding:20px 16px;min-height:auto}
+  #screen-1 .e1-projects-header{padding:0 48px}
   #screen-1 .project-card{flex-direction:column;align-items:flex-start}
   #screen-1 .project-card-main{width:100%}
   #screen-1 .project-card-menu{align-self:flex-end}


### PR DESCRIPTION
## Summary
- increase the saved projects panel height so the list has more room
- center the saved projects heading while pinning the back button to the left edge
- update the project card menu button styling so the three-dot icon inherits the text color and stays visible on desktop

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d3f2940e38832daa5e61b47d317e85