### PR TITLE
Align saved project step labeling

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -858,9 +858,10 @@ function createProjectListItem(proj){
 }
 
 function formatProjectStepLabel(proj){
-  const total = Number.isFinite(proj.stepCount) ? Math.max(0, Math.floor(proj.stepCount)) : 0;
-  const last = Number.isFinite(proj.lastViewedStep) ? Math.max(0, Math.floor(proj.lastViewedStep)) : 0;
-  const current = total > 0 ? Math.min(last + 1, total) : 0;
+  const rawTotal = Number.isFinite(proj.stepCount) ? Math.floor(proj.stepCount) : 0;
+  const total = Math.max(0, rawTotal - 1);
+  const rawCurrent = Number.isFinite(proj.lastViewedStep) ? Math.floor(proj.lastViewedStep) : 0;
+  const current = Math.min(Math.max(rawCurrent, 0), total);
   const currentLabel = current.toLocaleString();
   const totalLabel = total.toLocaleString();
   return `Current step ${currentLabel} / ${totalLabel}`;


### PR DESCRIPTION
## Summary
- clamp saved project step metadata to match viewer progress calculations
- continue localizing the zero-based step counters for saved project cards

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d662e53a18832d9ef1c3e353137649